### PR TITLE
feat(link2app): adding an option to go back to caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ npm install @moneytree/mt-link-javascript-sdk
 
 Then you can use it directly in your code:
 ```js
-var mtLinkSdk = require('mt-link-javascript-sdk'); // es5
+var mtLinkSdk = require('@moneytree/mt-link-javascript-sdk'); // es5
 // or
-import mtLinkSdk from 'mt-link-javascript-sdk'; // es-next
+import mtLinkSdk from '@moneytree/mt-link-javascript-sdk'; // es-next
 ```
 The source also include a Typescript definition.
 
@@ -41,7 +41,8 @@ Config properties:
   clientId, // string; // The id of the application that asks for authorization.
   response_type, // string; // Tells the authorization server which grant to execute.
   scope, // string[]; // A list of permissions that the application requires.
-  redirectUri, // string; // Holds a URL. A successful response from this endpoint results in a redirect to this URL.
+  redirectUri, // string; // URI to return the user to after authorization is complete.
+  continueTo, // string; // [optional] Parameter appended as `continue` to the `redirectUri`.
   locale, // string; // [optional] To force the display to a specific language (e.g.: en-AU)
   state, // string; // [optional] An opaque value, used for security purposes. If this request parameter is set in the request, then it is returned to the application as part of the redirect_uri.
   appToken, // string; // [optional] The Access Token granted through oauth
@@ -50,15 +51,18 @@ Config properties:
 ```
 
 ### Open the page for the user to authorize your application
-`authorize()`
-
-### Set the access token after init
-`setToken()`
+`authorize({ newTab })`
 
 ### Open the setting page of the user account
-`openSettings()`
+`openSettings({ newTab, backTo })`
 
 ### Open the vault to let the user add credentials
-`openVault()`
+`openVault({ newTab, backTo })`
 
-> Note: `authorize`, `openSettings`, and `openVault` can open in a new tab by sending `true` as an argument.
+### Optional parameters
+```js
+{
+  newTab, // boolean; // Open in a new tab if set to TRUE
+  backTo, // string(url); // Holds a URL. Used to come back to your app. Default to current URI.
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ interface Config {
   isTestEnvironment?: boolean;
   scope: string[];
   redirectUri?: string;
+  continueTo?: string;
   responseType?: string;
-  appToken?: string;
   locale?: string;
   state?: string;
 }
@@ -15,11 +15,17 @@ interface Config {
 interface Params {
   client_id: string;
   redirect_uri: string;
+  continue: string;
   response_type: string;
   scope: string;
+  back?: string;
   locale?: string;
-  access_token?: string;
   state?: string;
+}
+
+interface LinkOptions {
+  backTo?: string,
+  newTab?: boolean
 }
 
 class LinkSDK {
@@ -34,9 +40,9 @@ class LinkSDK {
     this.params = {
       client_id:config. clientId,
       redirect_uri: config.redirectUri || `${location.protocol}//${location.host}/callback`,
+      continue: config.continueTo || '',
       response_type: config.responseType || 'token',
       scope: config.scope.join(' '),
-      access_token: config.appToken,
       locale: config.locale,
       state: config.state
     };
@@ -48,28 +54,25 @@ class LinkSDK {
     };
   }
 
-  // Set the token from callback or server
-  setToken(appToken: string): void {
-    this.params.access_token = appToken;
-  }
-
   // Open My Account to authorize application to use MtLink API
-  authorize(newTab: boolean = false): void {
+  authorize({ newTab = false } = {}): void {
     const { PATHS: { OAUTH }} = MY_ACCOUNT;
-    const params = qs.stringify(this.params);
+    const params = qs.stringify({ ...this.params });
     window.open(`https://${this.domains.myaccount}/${OAUTH}?${params}`, newTab ? '_blank' : '_self');
   }
 
   // Open the Vault page
-  openVault(newTab: boolean = false): void {
-    const params = qs.stringify(this.params);
+  openVault(options: LinkOptions = {}): void {
+    const { newTab = false, backTo = location.href } = options;
+    const params = qs.stringify({ ...this.params, back: backTo });
     window.open(`https://${this.domains.vault}?${params}`, newTab ? '_blank' : '_self');
   }
 
   // Open the Guest settings page
-  openSettings(newTab: boolean = false): void {
+  openSettings(options: LinkOptions = {}): void {
+    const { newTab = false, backTo = location.href } = options;
     const { PATHS: { SETTINGS }} = MY_ACCOUNT;
-    const params = qs.stringify(this.params);
+    const params = qs.stringify({ ...this.params, back: backTo });
     window.open(`https://${this.domains.myaccount}?${params}/${SETTINGS}`, newTab ? '_blank' : '_self');
   }
 }


### PR DESCRIPTION
Breaking changes:
- `authorize`, `openVault`, `openSettings` takes different arguments
- `setToken ` has been removed
- `appToken` option has been removed