### PR TITLE
Update readme: remove references to appToken (deprecated) and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Config properties:
   continueTo, // string; // [optional] Parameter appended as `continue` to the `redirectUri`.
   locale, // string; // [optional] To force the display to a specific language (e.g.: en-AU).
   state, // string; // [optional] An opaque value, used for security purposes. If this request parameter is set in the request, then it is returned to the application as part of the redirect_uri.
-  appToken, // string; // [optional] The Access Token granted through oauth
-  isTestEnvironment // boolean; // [optional] If you wanna use the staging or production environemnt
+  isTestEnvironment // boolean; // [optional] If you wanna use the staging or production environment
 }
 ```
 


### PR DESCRIPTION
As title.

- `appToken` is no longer used and should be removed from readme.
- Fix small typo.