### PR TITLE
[LAPI-480] Refactor tokenInfo API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -169,8 +169,6 @@ tokenInfo.isMtClient // for internal use
 | Parameter | Type | Required | Default Value | Description |
 | - | - | - | - | - |
 | token | string | true | | Token you wish to get info for. |
-| options | object | false | Value set during `init`. | Optional parameters. |
-| options.redirectUri | string | false | Value set during `init`. | Make sure the value of `redirectUri` here is the same state value used during `authorize` or `onboard` call.<br /><br /><strong>NOTE:</strong> The SDK will throw an error if both this parameter and the default value from the [init options](?id=api-init_options) are undefined. |
 
 ### logout
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,16 +154,19 @@ You can validate a token or get guest or resource server information related to 
 
 ```javascript
 const tokenInfo = await mtLinkSdk.tokenInfo(token, options);
-tokenInfo.guestUid // guest's uid
-tokenInfo.country // guest's country
-tokenInfo.currency // guest's currency
-tokenInfo.language // guest's language
-tokenInfo.resourceServer // resource server domain
-tokenInfo.clientId // app client id
-tokenInfo.clientName // app name
-tokenInfo.expTimestamp // token expiration timestamp
-tokenInfo.scopes // token access scopes
-tokenInfo.isMtClient // for internal use
+tokenInfo.iat // token creation timestamp,
+tokenInfo.exp // token expiration timestamp,
+tokenInfo.sub // guest uid or null,
+tokenInfo.scope // string with space separated scopes
+tokenInfo.client_id // application client id or null
+tokenInfo.app // application related information or null
+tokenInfo.app.name // application name
+tokenInfo.app.is_mt // is moneytree client (internal usage)
+tokenInfo.guest // guest related information or null
+tokenInfo.guest.email // guest email if available
+tokenInfo.guest.country // guest country
+tokenInfo.guest.currency // guest currency,
+tokenInfo.guest.lang // guest language
 ```
 
 | Parameter | Type | Required | Default Value | Description |

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -63,7 +63,6 @@ describe('index', () => {
     mocked(tokenInfo).mockResolvedValueOnce('test');
     const result7 = await instance.tokenInfo('test');
     expect(result7).toBe('test');
-    expect(tokenInfo).toBeCalledWith(storedOptions, 'test', undefined);
   });
 
   test('mtLinkSdk', () => {

--- a/src/api/__tests__/token-info.test.ts
+++ b/src/api/__tests__/token-info.test.ts
@@ -1,5 +1,4 @@
 import fetch from 'jest-fetch-mock';
-import qs from 'qs';
 
 import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
@@ -35,54 +34,22 @@ describe('api', () => {
       );
     });
 
-    test('redirectUri is required', async () => {
-      const instance = new MtLinkSdk();
-
-      await expect(tokenInfo(instance.storedOptions, token)).rejects.toThrow(
-        '[mt-link-sdk] Missing option `redirectUri` in `tokenInfo`, make sure to pass one via `tokenInfo` options or `init` options.'
-      );
-    });
-
     test('make request', async () => {
       fetch.mockClear();
       fetch.mockResponseOnce(JSON.stringify(response));
 
       await tokenInfo(mtLinkSdk.storedOptions, token);
 
-      const query = qs.stringify({
-        client_id: clientId,
-        redirect_uri: redirectUri,
-        response_type: 'token',
-      });
-
-      const url = `${MY_ACCOUNT_DOMAINS.production}/oauth/token/info.json?${query}`;
+      const url = `${MY_ACCOUNT_DOMAINS.production}/oauth/token/info.json`;
 
       expect(fetch).toBeCalledTimes(1);
       expect(fetch).toBeCalledWith(url, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${token}`,
+          'x-api-key': clientId,
         },
       });
-    });
-
-    test('use option', async () => {
-      fetch.mockClear();
-      fetch.mockResponseOnce(JSON.stringify(response));
-
-      const newRedirectUri = 'newRedirectUri';
-
-      await tokenInfo(mtLinkSdk.storedOptions, token, { redirectUri: newRedirectUri });
-
-      const query = qs.stringify({
-        client_id: clientId,
-        redirect_uri: newRedirectUri,
-        response_type: 'token',
-      });
-
-      const url = `${MY_ACCOUNT_DOMAINS.production}/oauth/token/info.json?${query}`;
-
-      expect(fetch.mock.calls[0][0]).toBe(url);
     });
 
     test('failed to request', async () => {

--- a/src/api/__tests__/token-info.test.ts
+++ b/src/api/__tests__/token-info.test.ts
@@ -20,7 +20,7 @@ describe('api', () => {
         name: 'aud-name',
       },
       exp: 'exp',
-      scopes: 'scopes',
+      scopes: ['scopes'],
     };
 
     const mtLinkSdk = new MtLinkSdk();

--- a/src/api/token-info.ts
+++ b/src/api/token-info.ts
@@ -1,3 +1,5 @@
+import { stringify } from 'qs';
+import { generateConfigs } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, TokenInfo } from '../typings';
 
@@ -11,12 +13,17 @@ export default async function tokenInfo(
     throw new Error('[mt-link-sdk] Missing parameter `token` in `tokenInfo`.');
   }
 
+  const queryString = stringify({
+    client_id: clientId,
+    configs: generateConfigs()
+  })
+
   try {
-    const response = await fetch(`${MY_ACCOUNT_DOMAINS[mode]}/oauth/token/info.json`, {
+    const response = await fetch(`${MY_ACCOUNT_DOMAINS[mode]}/oauth/token/info.json?${queryString}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
-        'x-api-key': clientId as string,
+        'API-Version': '1604911588',
       },
     });
 
@@ -26,18 +33,7 @@ export default async function tokenInfo(
       throw new Error(result.error_description);
     }
 
-    return {
-      guestUid: result.uid,
-      resourceServer: result.resource_server,
-      country: result.country,
-      currency: result.currency,
-      language: result.locale,
-      clientId: result.aud.uid,
-      clientName: result.aud.name,
-      expTimestamp: result.exp,
-      scopes: result.scopes,
-      isMtClient: result.is_mt_client,
-    };
+    return result;
   } catch (error) {
     throw new Error(`[mt-link-sdk] \`tokenInfo\` execution failed. ${error}`);
   }

--- a/src/api/token-info.ts
+++ b/src/api/token-info.ts
@@ -1,42 +1,24 @@
-import qs from 'qs';
-
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
-import { StoredOptions, TokenInfoOptions, TokenInfo } from '../typings';
+import { StoredOptions, TokenInfo } from '../typings';
 
 export default async function tokenInfo(
   storedOptions: StoredOptions,
-  token: string,
-  options: TokenInfoOptions = {}
+  token: string
 ): Promise<TokenInfo> {
-  const { clientId, redirectUri: defaultRedirectUri, mode } = storedOptions;
-  const { redirectUri = defaultRedirectUri } = options;
+  const { mode, clientId } = storedOptions;
 
   if (!token) {
     throw new Error('[mt-link-sdk] Missing parameter `token` in `tokenInfo`.');
   }
 
-  if (!redirectUri) {
-    throw new Error(
-      '[mt-link-sdk] Missing option `redirectUri` in `tokenInfo`, make sure to pass one via `tokenInfo` options or `init` options.'
-    );
-  }
-
-  const queryParams = qs.stringify({
-    client_id: clientId, // TODO: test if we need this
-    redirect_uri: redirectUri,
-    response_type: 'token',
-  });
-
   try {
-    const response = await fetch(
-      `${MY_ACCOUNT_DOMAINS[mode]}/oauth/token/info.json?${queryParams}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
+    const response = await fetch(`${MY_ACCOUNT_DOMAINS[mode]}/oauth/token/info.json`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-api-key': clientId as string,
+      },
+    });
 
     const result = await response.json();
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -72,7 +72,7 @@ export function generateConfigs(configs: ConfigsOptions = {}): string {
   ];
 
   for (const key in configs) {
-    if (configKeys.includes(key)) {
+    if (configKeys.indexOf(key) !== -1) {
       snakeCaseConfigs[snakeCase(key)] = configs[key as keyof ConfigsOptions];
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import {
   InitOptions,
   AuthorizeOptions,
   ExchangeTokenOptions,
-  TokenInfoOptions,
   RequestMagicLinkOptions,
   TokenInfo,
   Mode,
@@ -76,8 +75,8 @@ export class MtLinkSdk {
     return exchangeToken(this.storedOptions, options);
   }
 
-  public tokenInfo(token: string, options?: TokenInfoOptions): Promise<TokenInfo> {
-    return tokenInfo(this.storedOptions, token, options);
+  public tokenInfo(token: string): Promise<TokenInfo> {
+    return tokenInfo(this.storedOptions, token);
   }
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -111,14 +111,21 @@ export interface RequestMagicLinkOptions extends ConfigsOptions {
 }
 
 export interface TokenInfo {
-  guestUid: string;
-  resourceServer: string;
-  country: string;
-  currency: string;
-  language: string;
-  clientName: string;
-  clientId: string;
-  expTimestamp: number;
-  scopes: Scopes;
-  isMtClient: boolean;
+  iss: string;
+  iat: number;
+  exp: number;
+  aud: string[];
+  sub: null | string;
+  scope: string;
+  client_id: null | string;
+  app: null | {
+    name: string;
+    is_mt: boolean;
+  };
+  guest: null | {
+    email: string;
+    country: string;
+    currency: string;
+    lang: string;
+  };
 }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -110,8 +110,6 @@ export interface RequestMagicLinkOptions extends ConfigsOptions {
   magicLinkTo?: MagicLinkTo;
 }
 
-export type TokenInfoOptions = Omit<Omit<OAuthSharedParams, 'state'>, 'codeVerifier'>;
-
 export interface TokenInfo {
   guestUid: string;
   resourceServer: string;


### PR DESCRIPTION
- remove `tokenInfo` unnecessary options and standardize response