### PR TITLE
Introduce new APIs that returns URLs used in existing APIs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ mtLinkSdk.setSamlSubjectId(samlSubjectId);
 
 ### authorize
 
-OAuth authorization method to request guest consent to access data via the [Link API](https://getmoneytree.com/au/link/about).<br /><br />
+OAuth authorization method to request guest consent to access data via the [Link API](https://getmoneytree.com/jp/link/about).<br /><br />
 For [security reasons](https://developer.okta.com/blog/2019/08/22/okta-authjs-pkce#why-you-should-never-use-the-implicit-flow-again) we removed support for implicit flow. We have opted for the [PKCE](https://auth0.com/docs/flows/concepts/auth-code-pkce)/[code grant](https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request/) flow.<br /><br />
 Guest login is required for this SDK to work, by default we will show the login screen and redirect the guest to the consent screen after they log in (Redirection happens immediately if they are currently logged in; you may pass the [forceLogout option](#authorize_option_force_logout) to force the guest to log in, even if they have an active session.)<br /><br />
 You may also choose to display the sign up form by default by passing the [authAction option](#authorize_option_auth_action).
@@ -107,6 +107,18 @@ mtLinkSdk.authorize(options);
 | options.codeChallenge                                               | string                                     | false    |                                                                                                                                                                | We only support SHA256 as code challenge method, therefore please ensure the `code_challenge` was generated using the SHA256 hash algorithm. [Click here](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce) for more details.</p><strong>NOTE:</strong> Set this value only if your server wish to use PKCE flow.                                                                                      |
 | options.pkce                                                        | boolean                                    | false    | false                                                                                                                                                          | Set to `true` if you wish to use PKCE flow on the client side, SDK will automatically generate the code challenge from a locally generated code verifier and use the code verifier in [exchangeToken](#exchangetoken).                                                                                                                                                                                                        |
 | <span id="authorize_option_force_logout">options.forceLogout</span> | boolean                                    | false    | `false`                                                                                                                                                        | Force existing guest session to logout and call authorize with a clean state.                                                                                                                                                                                                                                                                                                                                                 |
+
+### authorizeUrl
+
+This method generates an URL for OAuth authorization that requires guest consent to access data via [Link API](https://getmoneytree.com/jp/link/about). See `authorize` API for authorization details.
+
+<h6>Usage:</h6>
+
+```javascript
+mtLinkSdk.authorizeUrl(options);
+```
+
+This API has exactly the same parameters as `authorize`, the only difference being that it returns an URL instead of opening immediately with `window.open`.
 
 ### onboard
 
@@ -131,6 +143,18 @@ mtLinkSdk.onboard(options);
 | ------------- | ------ | -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | options       | object | false    | Value set during `init`. | Optional parameters.<br /><br />Most options are the same as the [authorize method](#authorize) options and [common options](#common-api-options) with a few exceptions.<br /><br />Unsupported options from [authorize](#authorize) and [common options](#common-api-options) are:<li>forceLogout</li><li>authAction</li><li>showAuthToggle</li><li>showRememberMe</li> |
 | options.email | string | true     | Value set during `init`. | A new Moneytree account will be created with this email address. If an existing account with this email exists, the guest will be redirected to the login screen.<br /><br /><strong>NOTE:</strong> SDK will throw an error if both values here and from the [init options](?id=api-init_options) are undefined.                                                         |
+
+### onboardUrl
+
+This method generates a URL for guest onboarding. See the `onboard` API for more information on onboarding.
+
+<h6>Usage:</h6>
+
+```javascript
+mtLinkSdk.onboardUrl(options);
+```
+
+This API has exactly the same parameters as `onboard`, the only difference being that it returns an URL instead of opening immediately with `window.open`.
 
 ### exchangeToken
 
@@ -218,6 +242,18 @@ mtLinkSdk.openService(serviceId, options);
 | options                    | object                                                                                                                 | false    | Value set during `init`. | Optional parameters. Includes all options in [common options](#common-api-options).                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | options.view for Vault     | `services-list`, `service-connection`, `connection-setting`, `customer-support`                                        | false    |                          | We provide options for opening a specific page on Vault and MyAccount. Please check the following sessions:<br /> <li>[Open Vault Services Page](#open-vault-services-page)</li><li>[Open Vault Service Connection Page](#open-vault-service-connection-page)</li><li>[Open Vault Service Setting Page](#open-vault-service-setting-page)</li><li>[Open Vault Customer Support Page](#open-vault-customer-support-page)</li><br /><br /><strong>NOTE:</strong> The serviceId must be `vault` to enable this option. |
 | options.view for MyAccount | `authorized-applications`, `change-language`, `email-preferences`, `delete-account`, `update-email`, `update-password` | false    |                          | We provide options for opening a specific page on MyAccount. Please check the following sessions:<br /> <li>[Open MyAccount Page](#open-myaccount-page)</li> <br /><br /><strong>NOTE:</strong> The serviceId must be `myaccount` to enable this option.                                                                                                                                                                                                                                                            |
+
+### logoutUrl
+
+This method generates a URL to log out the guest. See the `logout` API for details on logout.
+
+<h6>Usage:</h6>
+
+```javascript
+mtLinkSdk.logoutUrl(options);
+```
+
+This API has exactly the same parameters as `logout`, the only difference being that it returns an URL instead of opening immediately with `window.open`.   
 
 #### Open Vault Services Page
 
@@ -311,9 +347,7 @@ mtLinkSdk.openService('myaccount', { view: 'settings/update-email' });
 
 ### openServiceUrl
 
-This method generates URLs to open various services provided by Moneytree, such as Moneytree Account Settings and Vault, etc. If you want to use the URLs for other purposes or load them in a different way, use this API instead of `openService`.
-
-<strong>NOTE:</strong> calling this API before calling `init` will open the services view without branding (company logo etc.)
+This method can generate URLs for various services provided by Moneytree, such as Moneytree Account Settings and Vault. See the `openService` API for details on combining the various options.
 
 <h6>Usage:</h6>
 
@@ -321,7 +355,7 @@ This method generates URLs to open various services provided by Moneytree, such 
 mtLinkSdk.openServiceUrl(serviceId, options);
 ```
 
-This API has exactly the same parameters as `openService`, the only difference being that it returns an URL instead of opening immediately with `window.open`.
+This API has exactly the same parameters as `openService`, the only difference being that it returns an URL instead of opening immediately with `window.open`.  
 
 ### requestLoginLink
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,6 +309,20 @@ mtLinkSdk.openService('myaccount', { view: 'settings/update-email' });
 | serviceId    | `myaccount` | true     |                                                                                                  | Open MyAccount                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | options.view | string      | false    | `settings` (for mobile view)<p><strong>OR</strong></p>`settings/update-email` (for desktop view) | Directly go to the chosen page. Currently supported locations include:<li>`settings` - Main Moneytree account settings screen.</li><li>`settings/authorized-applications` - List of apps currently connected to Moneytree.</li><li>`settings/change-language` - Change Moneytree account language screen.<li>`settings/email-preferences` - Change Moneytree email preferences screen</li><li>`settings/delete-account` - Delete Moneytree account screen.</li><li>`settings/update-email` - Change Moneytree account email screen.</li><li>`settings/update-password` - Change Moneytree account password screen.</li><br> If no value is provided, it goes to the top page of MyAccount. |
 
+### openServiceUrl
+
+This method generates URLs to open various services provided by Moneytree, such as Moneytree Account Settings and Vault, etc. If you want to use the URLs for other purposes or load them in a different way, use this API instead of `openService`.
+
+<strong>NOTE:</strong> calling this API before calling `init` will open the services view without branding (company logo etc.)
+
+<h6>Usage:</h6>
+
+```javascript
+mtLinkSdk.openServiceUrl(serviceId, options);
+```
+
+This API has exactly the same parameters as `openService`, the only difference being that it returns an URL instead of opening immediately with `window.open`.
+
 ### requestLoginLink
 
 Request for a password-less login link to be sent to the guest's email address. Clicking on the link in the email will log a guest in directly to the screen specified by the `loginLinkTo` parameter.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -9,6 +9,8 @@ import exchangeToken from '../api/exchange-token';
 import tokenInfo from '../api/token-info';
 import mtLinkSdk, { MtLinkSdk } from '..';
 
+import packageJson from '../../package.json';
+
 jest.mock('../api/authorize');
 jest.mock('../api/onboard');
 jest.mock('../api/logout');
@@ -66,6 +68,34 @@ describe('index', () => {
     mocked(tokenInfo).mockResolvedValueOnce('test');
     const result7 = await instance.tokenInfo('test');
     expect(result7).toBe('test');
+
+    const sdkVersion = packageJson.version;
+
+    const result8 = instance.authorizeUrl({ scopes: 'scopes' });
+    expect(result8).toBe(
+      'https://myaccount.getmoneytree.com/oauth/authorize?client_id=clientId&response_type=code&' +
+        'scope=scopes&redirect_uri=redirectUri&country=JP&saml_subject_id=samlSubjectId&' +
+        `configs=authn_method%3Dsso%26sdk_platform%3Djs%26sdk_version%3D${sdkVersion}`
+    );
+
+    const result9 = instance.onboardUrl({ scopes: 'scopes' });
+    expect(result9).toBe(
+      'https://myaccount.getmoneytree.com/onboard?client_id=clientId&response_type=code&' +
+        'scope=scopes&redirect_uri=redirectUri&country=JP&' +
+        `configs=authn_method%3Dsso%26sdk_platform%3Djs%26sdk_version%3D${sdkVersion}`
+    );
+
+    const result10 = instance.logoutUrl({ backTo: 'backTo' });
+    expect(result10).toBe(
+      'https://myaccount.getmoneytree.com/guests/logout?client_id=clientId&saml_subject_id=samlSubjectId&' +
+        `configs=back_to%3DbackTo%26authn_method%3Dsso%26sdk_platform%3Djs%26sdk_version%3D${sdkVersion}`
+    );
+
+    const result11 = instance.openServiceUrl('vault');
+    expect(result11).toBe(
+      'https://vault.getmoneytree.com?client_id=clientId&saml_subject_id=samlSubjectId&' +
+        `configs=authn_method%3Dsso%26sdk_platform%3Djs%26sdk_version%3D${sdkVersion}`
+    );
   });
 
   test('mtLinkSdk', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ import openService from '../api/open-service';
 import requestLoginLink from '../api/request-login-link';
 import exchangeToken from '../api/exchange-token';
 import tokenInfo from '../api/token-info';
-import mtLinkSdk, { MtLinkSdk } from '..';
+import mtLinkSdk, { Mode, MtLinkSdk } from '..';
 
 import packageJson from '../../package.json';
 
@@ -51,13 +51,13 @@ describe('index', () => {
     expect(result3).toBeUndefined();
     expect(logout).toBeCalledWith(storedOptions, { backTo: 'backTo' });
 
-    const result4 = instance.openService('test');
+    const result4 = instance.openService('myaccount');
     expect(result4).toBeUndefined();
-    expect(openService).toBeCalledWith(storedOptions, 'test', undefined);
+    expect(openService).toBeCalledWith(storedOptions, 'myaccount', undefined);
 
-    const result5 = await instance.requestLoginLink({ loginLinkTo: 'loginLinkTo' });
+    const result5 = await instance.requestLoginLink({ loginLinkTo: 'settings' });
     expect(result5).toBeUndefined();
-    expect(requestLoginLink).toBeCalledWith(storedOptions, { loginLinkTo: 'loginLinkTo' });
+    expect(requestLoginLink).toBeCalledWith(storedOptions, { loginLinkTo: 'settings' });
 
     mocked(exchangeToken).mockResolvedValueOnce('test');
     const result6 = await instance.exchangeToken({ code: 'code' });
@@ -96,6 +96,8 @@ describe('index', () => {
       'https://vault.getmoneytree.com?client_id=clientId&saml_subject_id=samlSubjectId&' +
         `configs=authn_method%3Dsso%26sdk_platform%3Djs%26sdk_version%3D${sdkVersion}`
     );
+
+    instance.openServiceUrl('myaccount');
   });
 
   test('mtLinkSdk', () => {
@@ -122,8 +124,8 @@ describe('index', () => {
 
   test('invalid mode default to production', () => {
     mtLinkSdk.init('clientId', {
-      // @ts-ignore: set mode to unsupported value
-      mode: 'invalid'
+      // force cast invalid value so that we can use it for testing
+      mode: 'invalid' as Mode
     });
 
     expect(mtLinkSdk.storedOptions.mode).toBe('production');

--- a/src/api/__tests__/logout-url.test.ts
+++ b/src/api/__tests__/logout-url.test.ts
@@ -1,0 +1,62 @@
+import qs from 'qs';
+
+import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
+import { MtLinkSdk } from '../..';
+import logoutUrl from '../logout-url';
+import { generateConfigs } from '../../helper';
+
+describe('api', () => {
+  describe('logout-url', () => {
+    test('without calling init', () => {
+      const url = logoutUrl(new MtLinkSdk().storedOptions);
+
+      const query = qs.stringify({
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/guests/logout?${query}`);
+    });
+
+    test('after calling init', () => {
+      window.open = jest.fn();
+
+      const clientId = 'clientId';
+      const cobrandClientId = 'cobrandClientId';
+      const locale = 'locale';
+
+      const mtLinkSkd = new MtLinkSdk();
+      mtLinkSkd.init(clientId, {
+        locale,
+        cobrandClientId
+      });
+      const url = logoutUrl(mtLinkSkd.storedOptions);
+
+      const query = qs.stringify({
+        client_id: clientId,
+        cobrand_client_id: cobrandClientId,
+        locale,
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/guests/logout?${query}`);
+    });
+
+    test('with options', () => {
+      window.open = jest.fn();
+
+      const backTo = 'backTo';
+
+      const url = logoutUrl(new MtLinkSdk().storedOptions, {
+        backTo
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          backTo
+        })
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/guests/logout?${query}`);
+    });
+  });
+});

--- a/src/api/__tests__/onboard-url.test.ts
+++ b/src/api/__tests__/onboard-url.test.ts
@@ -34,19 +34,6 @@ describe('api', () => {
       );
     });
 
-    test('email is required', () => {
-      const mtLinkSdk = new MtLinkSdk();
-      mtLinkSdk.init(clientId, {
-        redirectUri
-      });
-
-      expect(() => {
-        const url = onboardUrl(mtLinkSdk.storedOptions);
-      }).toThrow(
-        '[mt-link-sdk] Missing option `email` in `onboardUrl/onboard`, make sure to pass one via `onboardUrl/onboard` options or `init` options.'
-      );
-    });
-
     test('method call without options use default init value', () => {
       mockedStorage.set.mockClear();
 

--- a/src/api/__tests__/onboard.test.ts
+++ b/src/api/__tests__/onboard.test.ts
@@ -36,19 +36,6 @@ describe('api', () => {
       );
     });
 
-    test('email is required', () => {
-      const mtLinkSdk = new MtLinkSdk();
-      mtLinkSdk.init(clientId, {
-        redirectUri
-      });
-
-      expect(() => {
-        onboard(mtLinkSdk.storedOptions);
-      }).toThrow(
-        '[mt-link-sdk] Missing option `email` in `onboardUrl/onboard`, make sure to pass one via `onboardUrl/onboard` options or `init` options.'
-      );
-    });
-
     test('method call without options use default init value', () => {
       mockedStorage.set.mockClear();
       open.mockClear();

--- a/src/api/__tests__/open-service-url.test.ts
+++ b/src/api/__tests__/open-service-url.test.ts
@@ -1,0 +1,183 @@
+import qs from 'qs';
+
+import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../../server-paths';
+import { MtLinkSdk } from '../..';
+import openServiceUrl from '../open-service-url';
+import { generateConfigs } from '../../helper';
+
+describe('api', () => {
+  describe('open-service-url', () => {
+    const clientId = 'clientId';
+
+    test('myaccount', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'myaccount');
+
+      const query = qs.stringify({
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/?${query}`);
+    });
+
+    test('myaccount/change-language', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'myaccount', {
+        view: 'settings/change-language'
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/settings/change-language?${query}`);
+    });
+
+    test('vault', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        showRememberMe: false
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          showRememberMe: false
+        })
+      });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
+    });
+
+    test('vault/services-list', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        view: 'services-list',
+        type: 'bank',
+        group: 'grouping_testing',
+        search: 'vault',
+        showRememberMe: false
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          showRememberMe: false
+        }),
+        group: 'grouping_testing',
+        type: 'bank',
+        search: 'vault'
+      });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}/services?${query}`);
+    });
+
+    test('vault/service-connection', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        view: 'service-connection',
+        entityKey: 'fauxbank_test_bank',
+        showRememberMe: false
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          showRememberMe: false
+        })
+      });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}/service/fauxbank_test_bank?${query}`);
+    });
+
+    test('vault/connection-setting', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        view: 'connection-setting',
+        credentialId: '123',
+        showRememberMe: false
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          showRememberMe: false
+        })
+      });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}/connection/123?${query}`);
+    });
+
+    test('vault/customer-support', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        view: 'customer-support',
+        showRememberMe: false
+      });
+
+      const query = qs.stringify({
+        configs: generateConfigs({
+          showRememberMe: false
+        })
+      });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}/customer-support?${query}`);
+    });
+
+    test('link-kit', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'link-kit');
+
+      const query = qs.stringify({
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${LINK_KIT_DOMAINS.production}?${query}`);
+    });
+
+    test('calling after init will includes client id', () => {
+      const cobrandClientId = 'cobrandClientId';
+      const locale = 'locale';
+
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, {
+        locale,
+        cobrandClientId
+      });
+
+      const url = openServiceUrl(mtLinkSdk.storedOptions, 'myaccount');
+
+      const query = qs.stringify({
+        client_id: clientId,
+        cobrand_client_id: cobrandClientId,
+        locale,
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/?${query}`);
+    });
+
+    test('invalid service id', () => {
+      expect(() => {
+        openServiceUrl(new MtLinkSdk().storedOptions, 'invalid');
+      }).toThrow('[mt-link-sdk] Invalid `serviceId` in `openServiceUrl/openService`, got: invalid');
+    });
+
+    test('saml_subject_id is passed when initialized', () => {
+      const instance = new MtLinkSdk();
+      instance.init('clientId', { samlSubjectId: 'samlSubjectId' });
+
+      const url = openServiceUrl(instance.storedOptions, 'myaccount');
+
+      const query = qs.stringify({
+        client_id: 'clientId',
+        saml_subject_id: 'samlSubjectId',
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/?${query}`);
+    });
+
+    test('undefined saml_subject_id should not be passed down', () => {
+      const instance = new MtLinkSdk();
+      instance.init('clientId', { samlSubjectId: undefined });
+
+      const url = openServiceUrl(instance.storedOptions, 'myaccount');
+
+      const query = qs.stringify({
+        client_id: 'clientId',
+        configs: generateConfigs()
+      });
+
+      expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/?${query}`);
+    });
+  });
+});

--- a/src/api/__tests__/open-service-url.test.ts
+++ b/src/api/__tests__/open-service-url.test.ts
@@ -1,7 +1,7 @@
 import qs from 'qs';
 
 import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../../server-paths';
-import { MtLinkSdk } from '../..';
+import { MtLinkSdk, ServiceId } from '../..';
 import openServiceUrl from '../open-service-url';
 import { generateConfigs } from '../../helper';
 
@@ -147,7 +147,8 @@ describe('api', () => {
 
     test('invalid service id', () => {
       expect(() => {
-        openServiceUrl(new MtLinkSdk().storedOptions, 'invalid');
+        // force cast invalid value so that we can use it for testing
+        openServiceUrl(new MtLinkSdk().storedOptions, 'invalid' as ServiceId);
       }).toThrow('[mt-link-sdk] Invalid `serviceId` in `openServiceUrl/openService`, got: invalid');
     });
 

--- a/src/api/__tests__/open-service.test.ts
+++ b/src/api/__tests__/open-service.test.ts
@@ -1,7 +1,7 @@
 import qs from 'qs';
 
 import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../../server-paths';
-import { MtLinkSdk } from '../..';
+import { MtLinkSdk, ServiceId } from '../..';
 import openService from '../open-service';
 import { generateConfigs } from '../../helper';
 
@@ -193,7 +193,8 @@ describe('api', () => {
 
     test('invalid service id', () => {
       expect(() => {
-        openService(new MtLinkSdk().storedOptions, 'invalid');
+        // force cast invalid value so that we can use it for testing
+        openService(new MtLinkSdk().storedOptions, 'invalid' as ServiceId);
       }).toThrow('[mt-link-sdk] Invalid `serviceId` in `openServiceUrl/openService`, got: invalid');
     });
 

--- a/src/api/__tests__/open-service.test.ts
+++ b/src/api/__tests__/open-service.test.ts
@@ -194,7 +194,7 @@ describe('api', () => {
     test('invalid service id', () => {
       expect(() => {
         openService(new MtLinkSdk().storedOptions, 'invalid');
-      }).toThrow('[mt-link-sdk] Invalid `serviceId` in `openService`, got: invalid');
+      }).toThrow('[mt-link-sdk] Invalid `serviceId` in `openServiceUrl/openService`, got: invalid');
     });
 
     test('saml_subject_id is passed when initialized', () => {

--- a/src/api/authorize-url.ts
+++ b/src/api/authorize-url.ts
@@ -1,0 +1,58 @@
+import { stringify } from 'qs';
+
+import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge } from '../helper';
+import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { StoredOptions, AuthorizeUrlOptions } from '../typings';
+import storage from '../storage';
+
+export default function authorize(storedOptions: StoredOptions, options: AuthorizeUrlOptions = {}): string {
+  const {
+    mode,
+    clientId,
+    cobrandClientId,
+    locale,
+    scopes: defaultScopes,
+    redirectUri: defaultRedirectUri,
+    samlSubjectId
+  } = storedOptions;
+
+  if (!clientId) {
+    throw new Error('[mt-link-sdk] Make sure to call `init` before calling `authorizeUrl/authorize`.');
+  }
+
+  const {
+    scopes = defaultScopes,
+    redirectUri = defaultRedirectUri,
+    pkce = false,
+    codeChallenge,
+    state,
+    ...rest
+  } = options;
+
+  if (!redirectUri) {
+    throw new Error(
+      '[mt-link-sdk] Missing option `redirectUri` in `authorizeUrl/authorize`, make sure to pass one via `authorizeUrl/authorize` options or `init` options.'
+    );
+  }
+
+  storage.del('cv');
+
+  const cc = codeChallenge || (pkce && generateCodeChallenge());
+
+  const queryString = stringify({
+    client_id: clientId,
+    cobrand_client_id: cobrandClientId,
+    response_type: 'code',
+    scope: constructScopes(scopes),
+    redirect_uri: redirectUri,
+    code_challenge: cc || undefined,
+    code_challenge_method: cc ? 'S256' : undefined,
+    state,
+    country: 'JP',
+    locale,
+    saml_subject_id: samlSubjectId,
+    configs: generateConfigs(mergeConfigs(storedOptions, rest))
+  });
+
+  return `${MY_ACCOUNT_DOMAINS[mode]}/oauth/authorize?${queryString}`;
+}

--- a/src/api/authorize.ts
+++ b/src/api/authorize.ts
@@ -1,70 +1,13 @@
-import { stringify } from 'qs';
-
-import {
-  constructScopes,
-  generateConfigs,
-  mergeConfigs,
-  getIsTabValue,
-  generateCodeChallenge,
-  openWindow
-} from '../helper';
-import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { getIsTabValue, openWindow } from '../helper';
 import { StoredOptions, AuthorizeOptions } from '../typings';
-import storage from '../storage';
+import authorizeUrl from './authorize-url';
 
 export default function authorize(storedOptions: StoredOptions, options: AuthorizeOptions = {}): void {
   if (!window) {
     throw new Error('[mt-link-sdk] `authorize` only works in the browser.');
   }
 
-  const {
-    mode,
-    clientId,
-    cobrandClientId,
-    locale,
-    scopes: defaultScopes,
-    redirectUri: defaultRedirectUri,
-    samlSubjectId
-  } = storedOptions;
+  const { isNewTab, ...restOptions } = options;
 
-  if (!clientId) {
-    throw new Error('[mt-link-sdk] Make sure to call `init` before calling `authorize`.');
-  }
-
-  const {
-    scopes = defaultScopes,
-    redirectUri = defaultRedirectUri,
-    pkce = false,
-    codeChallenge,
-    isNewTab,
-    state,
-    ...rest
-  } = options;
-
-  if (!redirectUri) {
-    throw new Error(
-      '[mt-link-sdk] Missing option `redirectUri` in `authorize`, make sure to pass one via `authorize` options or `init` options.'
-    );
-  }
-
-  storage.del('cv');
-
-  const cc = codeChallenge || (pkce && generateCodeChallenge());
-
-  const queryString = stringify({
-    client_id: clientId,
-    cobrand_client_id: cobrandClientId,
-    response_type: 'code',
-    scope: constructScopes(scopes),
-    redirect_uri: redirectUri,
-    code_challenge: cc || undefined,
-    code_challenge_method: cc ? 'S256' : undefined,
-    state,
-    country: 'JP',
-    locale,
-    saml_subject_id: samlSubjectId,
-    configs: generateConfigs(mergeConfigs(storedOptions, rest))
-  });
-
-  openWindow(`${MY_ACCOUNT_DOMAINS[mode]}/oauth/authorize?${queryString}`, getIsTabValue(isNewTab));
+  openWindow(authorizeUrl(storedOptions, restOptions), getIsTabValue(isNewTab));
 }

--- a/src/api/logout-url.ts
+++ b/src/api/logout-url.ts
@@ -1,0 +1,19 @@
+import { stringify } from 'qs';
+
+import { generateConfigs, mergeConfigs } from '../helper';
+import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { StoredOptions, LogoutUrlOptions } from '../typings';
+
+export default function logoutUrl(storedOptions: StoredOptions, options: LogoutUrlOptions = {}): string {
+  const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
+
+  const queryString = stringify({
+    client_id: clientId,
+    cobrand_client_id: cobrandClientId,
+    locale,
+    saml_subject_id: samlSubjectId,
+    configs: generateConfigs(mergeConfigs(storedOptions, options))
+  });
+
+  return `${MY_ACCOUNT_DOMAINS[mode]}/guests/logout?${queryString}`;
+}

--- a/src/api/logout.ts
+++ b/src/api/logout.ts
@@ -1,24 +1,13 @@
-import { stringify } from 'qs';
-
-import { generateConfigs, mergeConfigs, getIsTabValue, openWindow } from '../helper';
-import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { getIsTabValue, openWindow } from '../helper';
 import { StoredOptions, LogoutOptions } from '../typings';
+import logoutUrl from './logout-url';
 
 export default function logout(storedOptions: StoredOptions, options: LogoutOptions = {}): void {
   if (!window) {
     throw new Error(`[mt-link-sdk] \`logout\` only works in the browser.`);
   }
 
-  const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
-  const { isNewTab, ...rest } = options;
+  const { isNewTab, ...restOptions } = options;
 
-  const queryString = stringify({
-    client_id: clientId,
-    cobrand_client_id: cobrandClientId,
-    locale,
-    saml_subject_id: samlSubjectId,
-    configs: generateConfigs(mergeConfigs(storedOptions, rest))
-  });
-
-  openWindow(`${MY_ACCOUNT_DOMAINS[mode]}/guests/logout?${queryString}`, getIsTabValue(isNewTab));
+  openWindow(logoutUrl(storedOptions, restOptions), getIsTabValue(isNewTab));
 }

--- a/src/api/onboard-url.ts
+++ b/src/api/onboard-url.ts
@@ -1,0 +1,66 @@
+import { stringify } from 'qs';
+
+import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge } from '../helper';
+import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { StoredOptions, OnboardUrlOptions } from '../typings';
+import storage from '../storage';
+
+export default function onboardUrl(storedOptions: StoredOptions, options: OnboardUrlOptions = {}): string {
+  const {
+    mode,
+    clientId,
+    cobrandClientId,
+    locale,
+    scopes: defaultScopes,
+    redirectUri: defaultRedirectUri
+  } = storedOptions;
+
+  if (!clientId) {
+    throw new Error('[mt-link-sdk] Make sure to call `init` before calling `onboardUrl/onboard`.');
+  }
+
+  const {
+    scopes = defaultScopes,
+    redirectUri = defaultRedirectUri,
+    pkce = false,
+    codeChallenge,
+    state,
+    ...rest
+  } = options;
+
+  const configs = mergeConfigs(storedOptions, rest, ['authAction', 'showAuthToggle', 'showRememberMe', 'forceLogout']);
+
+  if (!redirectUri) {
+    throw new Error(
+      '[mt-link-sdk] Missing option `redirectUri` in `onboardUrl/onboard`, make sure to pass one via `onboardUrl/onboard` options or `init` options.'
+    );
+  }
+
+  const { email } = configs;
+
+  if (!email) {
+    throw new Error(
+      '[mt-link-sdk] Missing option `email` in `onboardUrl/onboard`, make sure to pass one via `onboardUrl/onboard` options or `init` options.'
+    );
+  }
+
+  storage.del('cv');
+
+  const cc = codeChallenge || (pkce && generateCodeChallenge());
+
+  const queryString = stringify({
+    client_id: clientId,
+    cobrand_client_id: cobrandClientId,
+    response_type: 'code',
+    scope: constructScopes(scopes),
+    redirect_uri: redirectUri,
+    code_challenge: cc || undefined,
+    code_challenge_method: cc ? 'S256' : undefined,
+    state,
+    country: 'JP',
+    locale,
+    configs: generateConfigs(configs)
+  });
+
+  return `${MY_ACCOUNT_DOMAINS[mode]}/onboard?${queryString}`;
+}

--- a/src/api/onboard-url.ts
+++ b/src/api/onboard-url.ts
@@ -36,14 +36,6 @@ export default function onboardUrl(storedOptions: StoredOptions, options: Onboar
     );
   }
 
-  const { email } = configs;
-
-  if (!email) {
-    throw new Error(
-      '[mt-link-sdk] Missing option `email` in `onboardUrl/onboard`, make sure to pass one via `onboardUrl/onboard` options or `init` options.'
-    );
-  }
-
   storage.del('cv');
 
   const cc = codeChallenge || (pkce && generateCodeChallenge());

--- a/src/api/onboard.ts
+++ b/src/api/onboard.ts
@@ -1,78 +1,13 @@
-import { stringify } from 'qs';
-
-import {
-  constructScopes,
-  generateConfigs,
-  mergeConfigs,
-  getIsTabValue,
-  generateCodeChallenge,
-  openWindow
-} from '../helper';
-import { MY_ACCOUNT_DOMAINS } from '../server-paths';
+import { getIsTabValue, openWindow } from '../helper';
 import { StoredOptions, OnboardOptions } from '../typings';
-import storage from '../storage';
+import onboardUrl from './onboard-url';
 
 export default function onboard(storedOptions: StoredOptions, options: OnboardOptions = {}): void {
   if (!window) {
     throw new Error('[mt-link-sdk] `onboard` only works in the browser.');
   }
 
-  const {
-    mode,
-    clientId,
-    cobrandClientId,
-    locale,
-    scopes: defaultScopes,
-    redirectUri: defaultRedirectUri
-  } = storedOptions;
+  const { isNewTab, ...restOptions } = options;
 
-  if (!clientId) {
-    throw new Error('[mt-link-sdk] Make sure to call `init` before calling `onboard`.');
-  }
-
-  const {
-    scopes = defaultScopes,
-    redirectUri = defaultRedirectUri,
-    pkce = false,
-    codeChallenge,
-    isNewTab,
-    state,
-    ...rest
-  } = options;
-
-  const configs = mergeConfigs(storedOptions, rest, ['authAction', 'showAuthToggle', 'showRememberMe', 'forceLogout']);
-
-  if (!redirectUri) {
-    throw new Error(
-      '[mt-link-sdk] Missing option `redirectUri` in `onboard`, make sure to pass one via `onboard` options or `init` options.'
-    );
-  }
-
-  const { email } = configs;
-
-  if (!email) {
-    throw new Error(
-      '[mt-link-sdk] Missing option `email` in `onboard`, make sure to pass one via `onboard` options or `init` options.'
-    );
-  }
-
-  storage.del('cv');
-
-  const cc = codeChallenge || (pkce && generateCodeChallenge());
-
-  const queryString = stringify({
-    client_id: clientId,
-    cobrand_client_id: cobrandClientId,
-    response_type: 'code',
-    scope: constructScopes(scopes),
-    redirect_uri: redirectUri,
-    code_challenge: cc || undefined,
-    code_challenge_method: cc ? 'S256' : undefined,
-    state,
-    country: 'JP',
-    locale,
-    configs: generateConfigs(configs)
-  });
-
-  openWindow(`${MY_ACCOUNT_DOMAINS[mode]}/onboard?${queryString}`, getIsTabValue(isNewTab));
+  openWindow(onboardUrl(storedOptions, restOptions), getIsTabValue(isNewTab));
 }

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -5,10 +5,12 @@ import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../server-p
 import {
   StoredOptions,
   ServiceId,
-  OpenServicesUrlConfigsOptions,
   ConnectionSettingType,
   ServiceConnectionType,
-  ServicesListType
+  ServicesListType,
+  OpenServiceUrlOptions,
+  VaultOpenServiceOptions,
+  MyAccountOpenServiceOptions
 } from '../typings';
 
 interface QueryData {
@@ -22,10 +24,10 @@ interface QueryData {
 export default function openServiceUrl(
   storedOptions: StoredOptions,
   serviceId: ServiceId,
-  options: OpenServicesUrlConfigsOptions = {}
+  options: OpenServiceUrlOptions = {}
 ): string {
   const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
-  const { view = '', ...rest } = options;
+  const { view = '', ...rest } = options as VaultOpenServiceOptions | MyAccountOpenServiceOptions;
 
   const getQueryValue = (needStringify = true): string | QueryData => {
     const query: QueryData = {

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -1,0 +1,90 @@
+import { stringify } from 'qs';
+
+import { generateConfigs, mergeConfigs } from '../helper';
+import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../server-paths';
+import {
+  StoredOptions,
+  ServiceId,
+  OpenServicesUrlConfigsOptions,
+  ConnectionSettingType,
+  ServiceConnectionType,
+  ServicesListType
+} from '../typings';
+
+interface QueryData {
+  client_id?: string;
+  cobrand_client_id?: string;
+  locale?: string;
+  configs: string;
+  saml_subject_id?: string;
+}
+
+export default function openServiceUrl(
+  storedOptions: StoredOptions,
+  serviceId: ServiceId,
+  options: OpenServicesUrlConfigsOptions = {}
+): string {
+  const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
+  const { view = '', ...rest } = options;
+
+  const getQueryValue = (needStringify = true): string | QueryData => {
+    const query: QueryData = {
+      client_id: clientId,
+      cobrand_client_id: cobrandClientId,
+      locale,
+      saml_subject_id: samlSubjectId,
+      configs: generateConfigs(mergeConfigs(storedOptions, rest))
+    };
+
+    if (!needStringify) {
+      return query;
+    }
+
+    return stringify(query);
+  };
+
+  switch (serviceId) {
+    case 'vault':
+      if (!view) {
+        return `${VAULT_DOMAINS[mode]}?${getQueryValue()}`;
+      }
+
+      switch (view) {
+        case 'services-list':
+          // eslint-disable-next-line no-case-declarations
+          const { group, type, search } = options as ServicesListType;
+
+          return `${VAULT_DOMAINS[mode]}/services?${stringify({
+            ...(getQueryValue(false) as QueryData),
+            group,
+            type,
+            search
+          })}`;
+
+        case 'service-connection':
+          // eslint-disable-next-line no-case-declarations
+          const { entityKey } = options as ServiceConnectionType;
+
+          return `${VAULT_DOMAINS[mode]}/service/${entityKey}?${getQueryValue()}`;
+
+        case 'connection-setting':
+          // eslint-disable-next-line no-case-declarations
+          const { credentialId } = options as ConnectionSettingType;
+
+          return `${VAULT_DOMAINS[mode]}/connection/${credentialId}?${getQueryValue()}`;
+
+        case 'customer-support':
+        default:
+          return `${VAULT_DOMAINS[mode]}/customer-support?${getQueryValue()}`;
+      }
+
+    case 'myaccount':
+      return `${MY_ACCOUNT_DOMAINS[mode]}/${view}?${getQueryValue()}`;
+
+    case 'link-kit':
+      return `${LINK_KIT_DOMAINS[mode]}?${getQueryValue()}`;
+
+    default:
+      throw new Error(`[mt-link-sdk] Invalid \`serviceId\` in \`openServiceUrl/openService\`, got: ${serviceId}`);
+  }
+}

--- a/src/api/open-service.ts
+++ b/src/api/open-service.ts
@@ -1,23 +1,6 @@
-import { stringify } from 'qs';
-
-import { generateConfigs, mergeConfigs, getIsTabValue, openWindow } from '../helper';
-import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../server-paths';
-import {
-  StoredOptions,
-  ServiceId,
-  OpenServicesConfigsOptions,
-  ConnectionSettingType,
-  ServiceConnectionType,
-  ServicesListType
-} from '../typings';
-
-interface QueryData {
-  client_id?: string;
-  cobrand_client_id?: string;
-  locale?: string;
-  configs: string;
-  saml_subject_id?: string;
-}
+import { getIsTabValue, openWindow } from '../helper';
+import { StoredOptions, ServiceId, OpenServicesConfigsOptions } from '../typings';
+import openServiceUrl from './open-service-url';
 
 export default function openService(
   storedOptions: StoredOptions,
@@ -28,79 +11,7 @@ export default function openService(
     throw new Error('[mt-link-sdk] `openService` only works in the browser.');
   }
 
-  const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
-  const { isNewTab, view = '', ...rest } = options;
+  const { isNewTab, ...restOptions } = options;
 
-  const getQueryValue = (needStringify = true): string | QueryData => {
-    const query: QueryData = {
-      client_id: clientId,
-      cobrand_client_id: cobrandClientId,
-      locale,
-      saml_subject_id: samlSubjectId,
-      configs: generateConfigs(mergeConfigs(storedOptions, rest))
-    };
-
-    if (!needStringify) {
-      return query;
-    }
-
-    return stringify(query);
-  };
-
-  switch (serviceId) {
-    case 'vault':
-      if (!view) {
-        openWindow(`${VAULT_DOMAINS[mode]}?${getQueryValue()}`, getIsTabValue(isNewTab));
-        break;
-      }
-
-      switch (view) {
-        case 'services-list':
-          // eslint-disable-next-line no-case-declarations
-          const { group, type, search } = options as ServicesListType;
-
-          openWindow(
-            `${VAULT_DOMAINS[mode]}/services?${stringify({
-              ...(getQueryValue(false) as QueryData),
-              group,
-              type,
-              search
-            })}`,
-            getIsTabValue(isNewTab)
-          );
-          break;
-
-        case 'service-connection':
-          // eslint-disable-next-line no-case-declarations
-          const { entityKey } = options as ServiceConnectionType;
-
-          openWindow(`${VAULT_DOMAINS[mode]}/service/${entityKey}?${getQueryValue()}`, getIsTabValue(isNewTab));
-          break;
-
-        case 'connection-setting':
-          // eslint-disable-next-line no-case-declarations
-          const { credentialId } = options as ConnectionSettingType;
-
-          openWindow(`${VAULT_DOMAINS[mode]}/connection/${credentialId}?${getQueryValue()}`, getIsTabValue(isNewTab));
-          break;
-
-        case 'customer-support':
-        default:
-          openWindow(`${VAULT_DOMAINS[mode]}/customer-support?${getQueryValue()}`, getIsTabValue(isNewTab));
-          break;
-      }
-
-      break;
-
-    case 'myaccount':
-      openWindow(`${MY_ACCOUNT_DOMAINS[mode]}/${view}?${getQueryValue()}`, getIsTabValue(isNewTab));
-      break;
-
-    case 'link-kit':
-      openWindow(`${LINK_KIT_DOMAINS[mode]}?${getQueryValue()}`, getIsTabValue(isNewTab));
-      break;
-
-    default:
-      throw new Error(`[mt-link-sdk] Invalid \`serviceId\` in \`openService\`, got: ${serviceId}`);
-  }
+  openWindow(openServiceUrl(storedOptions, serviceId, restOptions), getIsTabValue(isNewTab));
 }

--- a/src/api/open-service.ts
+++ b/src/api/open-service.ts
@@ -1,11 +1,11 @@
 import { getIsTabValue, openWindow } from '../helper';
-import { StoredOptions, ServiceId, OpenServicesConfigsOptions } from '../typings';
+import { StoredOptions, ServiceId, OpenServiceOptions } from '../typings';
 import openServiceUrl from './open-service-url';
 
 export default function openService(
   storedOptions: StoredOptions,
   serviceId: ServiceId,
-  options: OpenServicesConfigsOptions = {}
+  options: OpenServiceOptions = {}
 ): void {
   if (!window) {
     throw new Error('[mt-link-sdk] `openService` only works in the browser.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import authorize from './api/authorize';
+import authorizeUrl from './api/authorize-url';
 import onboard from './api/onboard';
 import logout from './api/logout';
 import openService from './api/open-service';
@@ -18,7 +19,8 @@ import {
   RequestLoginLinkOptions,
   TokenInfo,
   Mode,
-  OpenServicesUrlConfigsOptions
+  OpenServicesUrlConfigsOptions,
+  AuthorizeUrlOptions
 } from './typings';
 
 export * from './typings';
@@ -52,6 +54,10 @@ export class MtLinkSdk {
 
   public authorize(options?: AuthorizeOptions): void {
     authorize(this.storedOptions, options);
+  }
+
+  public authorizeUrl(options?: AuthorizeUrlOptions): string {
+    return authorizeUrl(this.storedOptions, options);
   }
 
   public onboard(options?: OnboardOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import authorize from './api/authorize';
 import onboard from './api/onboard';
 import logout from './api/logout';
 import openService from './api/open-service';
+import openServiceUrl from './api/open-service-url';
 import requestLoginLink from './api/request-login-link';
 import exchangeToken from './api/exchange-token';
 import tokenInfo from './api/token-info';
@@ -16,7 +17,8 @@ import {
   ExchangeTokenOptions,
   RequestLoginLinkOptions,
   TokenInfo,
-  Mode
+  Mode,
+  OpenServicesUrlConfigsOptions
 } from './typings';
 
 export * from './typings';
@@ -62,6 +64,10 @@ export class MtLinkSdk {
 
   public openService(serviceId: ServiceId, options?: OpenServicesConfigsOptions): void {
     openService(this.storedOptions, serviceId, options);
+  }
+
+  public openServiceUrl(serviceId: ServiceId, options?: OpenServicesUrlConfigsOptions): string {
+    return openServiceUrl(this.storedOptions, serviceId, options);
   }
 
   public requestLoginLink(options?: RequestLoginLinkOptions): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import authorize from './api/authorize';
 import authorizeUrl from './api/authorize-url';
 import onboard from './api/onboard';
+import onboardUrl from './api/onboard-url';
 import logout from './api/logout';
 import logoutUrl from './api/logout-url';
 import openService from './api/open-service';
@@ -22,7 +23,8 @@ import {
   Mode,
   OpenServicesUrlConfigsOptions,
   AuthorizeUrlOptions,
-  LogoutUrlOptions
+  LogoutUrlOptions,
+  OnboardUrlOptions
 } from './typings';
 
 export * from './typings';
@@ -64,6 +66,10 @@ export class MtLinkSdk {
 
   public onboard(options?: OnboardOptions): void {
     onboard(this.storedOptions, options);
+  }
+
+  public onboardUrl(options?: OnboardUrlOptions): string {
+    return onboardUrl(this.storedOptions, options);
   }
 
   public logout(options?: LogoutOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,13 @@ import onboardUrl from './api/onboard-url';
 import logout from './api/logout';
 import logoutUrl from './api/logout-url';
 import openService from './api/open-service';
-import openServiceUrl from './api/open-service-url';
+import openServiceUrlApi from './api/open-service-url';
 import requestLoginLink from './api/request-login-link';
 import exchangeToken from './api/exchange-token';
 import tokenInfo from './api/token-info';
 import {
   StoredOptions,
   ServiceId,
-  OpenServicesConfigsOptions,
   LogoutOptions,
   InitOptions,
   AuthorizeOptions,
@@ -21,10 +20,17 @@ import {
   RequestLoginLinkOptions,
   TokenInfo,
   Mode,
-  OpenServicesUrlConfigsOptions,
   AuthorizeUrlOptions,
   LogoutUrlOptions,
-  OnboardUrlOptions
+  OnboardUrlOptions,
+  OpenServiceUrlOptions,
+  LinkKitOpenServiceUrlOptions,
+  MyAccountOpenServiceUrlOptions,
+  VaultOpenServiceUrlOptions,
+  VaultOpenServiceOptions,
+  LinkKitOpenServiceOptions,
+  MyAccountOpenServiceOptions,
+  OpenServiceOptions
 } from './typings';
 
 export * from './typings';
@@ -80,12 +86,18 @@ export class MtLinkSdk {
     return logoutUrl(this.storedOptions, options);
   }
 
-  public openService(serviceId: ServiceId, options?: OpenServicesConfigsOptions): void {
+  public openService(serviceId: 'link-kit', options?: LinkKitOpenServiceOptions): void;
+  public openService(serviceId: 'myaccount', options?: MyAccountOpenServiceOptions): void;
+  public openService(serviceId: 'vault', options?: VaultOpenServiceOptions): void;
+  public openService(serviceId: ServiceId, options?: OpenServiceOptions): void {
     openService(this.storedOptions, serviceId, options);
   }
 
-  public openServiceUrl(serviceId: ServiceId, options?: OpenServicesUrlConfigsOptions): string {
-    return openServiceUrl(this.storedOptions, serviceId, options);
+  public openServiceUrl(serviceId: 'link-kit', options?: LinkKitOpenServiceUrlOptions): string;
+  public openServiceUrl(serviceId: 'myaccount', options?: MyAccountOpenServiceUrlOptions): string;
+  public openServiceUrl(serviceId: 'vault', options?: VaultOpenServiceUrlOptions): string;
+  public openServiceUrl(serviceId: ServiceId, options?: OpenServiceUrlOptions): string {
+    return openServiceUrlApi(this.storedOptions, serviceId, options);
   }
 
   public requestLoginLink(options?: RequestLoginLinkOptions): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import authorize from './api/authorize';
 import authorizeUrl from './api/authorize-url';
 import onboard from './api/onboard';
 import logout from './api/logout';
+import logoutUrl from './api/logout-url';
 import openService from './api/open-service';
 import openServiceUrl from './api/open-service-url';
 import requestLoginLink from './api/request-login-link';
@@ -20,7 +21,8 @@ import {
   TokenInfo,
   Mode,
   OpenServicesUrlConfigsOptions,
-  AuthorizeUrlOptions
+  AuthorizeUrlOptions,
+  LogoutUrlOptions
 } from './typings';
 
 export * from './typings';
@@ -66,6 +68,10 @@ export class MtLinkSdk {
 
   public logout(options?: LogoutOptions): void {
     logout(this.storedOptions, options);
+  }
+
+  public logoutUrl(options?: LogoutUrlOptions): string {
+    return logoutUrl(this.storedOptions, options);
   }
 
   public openService(serviceId: ServiceId, options?: OpenServicesConfigsOptions): void {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -59,6 +59,9 @@ export type MyAccountPageType = { view?: LoginLinkTo };
 export type OpenServicesConfigsOptions = ConfigsOptions &
   (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
 
+export type OpenServicesUrlConfigsOptions = Omit<ConfigsOptions, 'isNewTab'> &
+  (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
+
 export type Scopes = string | string[];
 
 interface AuthorizeConfigsOptions {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -100,6 +100,7 @@ export interface ExchangeTokenOptions extends OAuthSharedParams {
 }
 
 export type LogoutOptions = ConfigsOptions;
+export type LogoutUrlOptions = Omit<ConfigsOptions, 'isNewTab'>;
 
 export type OnboardOptions = Omit<
   Omit<Omit<Omit<AuthorizeOptions, 'showAuthToggle'>, 'forceLogout'>, 'showRememberMe'>,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -59,7 +59,9 @@ export type MyAccountPageType = { view?: LoginLinkTo };
 export type OpenServicesConfigsOptions = ConfigsOptions &
   (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
 
-export type OpenServicesUrlConfigsOptions = Omit<ConfigsOptions, 'isNewTab'> &
+type ConfigsOptionsWithoutIsNewTab = Omit<ConfigsOptions, 'isNewTab'>;
+
+export type OpenServicesUrlConfigsOptions = ConfigsOptionsWithoutIsNewTab &
   (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
 
 export type Scopes = string | string[];
@@ -78,6 +80,8 @@ export interface AuthorizeOptions extends OAuthSharedParams, ConfigsOptions, Aut
   codeChallenge?: string;
   pkce?: boolean;
 }
+
+export type AuthorizeUrlOptions = Omit<AuthorizeOptions, 'isNewTab'>;
 
 export type Mode = 'production' | 'staging' | 'develop' | 'local';
 export type InitOptions = Omit<Omit<Omit<AuthorizeOptions, 'forceLogout'>, 'codeChallenge'>, 'pkce'> &

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -107,6 +107,8 @@ export type OnboardOptions = Omit<
   'authAction'
 >;
 
+export type OnboardUrlOptions = Omit<OnboardOptions, 'isNewTab'>;
+
 export type ServiceId = string | 'vault' | 'myaccount' | 'linkkit';
 
 export type LoginLinkTo =

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -26,7 +26,7 @@ export interface ConfigsOptions extends PrivateConfigsOptions {
 }
 
 export type ServicesListType = {
-  view?: 'services-list';
+  view: 'services-list';
   group?:
     | 'grouping_bank'
     | 'grouping_bank_credit_card'
@@ -48,21 +48,27 @@ export type ServicesListType = {
   search?: string;
 };
 
-export type ServiceConnectionType = { view?: 'service-connection'; entityKey: string };
+export type ServiceConnectionType = { view: 'service-connection'; entityKey: string };
 
-export type ConnectionSettingType = { view?: 'connection-setting'; credentialId: string };
+export type ConnectionSettingType = { view: 'connection-setting'; credentialId: string };
 
-export type CustomerSupportType = { view?: 'customer-support' };
+export type CustomerSupportType = { view: 'customer-support' };
 
-export type MyAccountPageType = { view?: LoginLinkTo };
-
-export type OpenServicesConfigsOptions = ConfigsOptions &
-  (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
+export type VaultOpenServiceOptions = ConfigsOptions &
+  (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType);
+export type MyAccountOpenServiceOptions = ConfigsOptions & { view: LoginLinkTo };
+export type LinkKitOpenServiceOptions = ConfigsOptions;
+export type OpenServiceOptions = VaultOpenServiceOptions | MyAccountOpenServiceOptions | LinkKitOpenServiceOptions;
 
 type ConfigsOptionsWithoutIsNewTab = Omit<ConfigsOptions, 'isNewTab'>;
-
-export type OpenServicesUrlConfigsOptions = ConfigsOptionsWithoutIsNewTab &
-  (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType | MyAccountPageType);
+export type VaultOpenServiceUrlOptions = ConfigsOptionsWithoutIsNewTab &
+  (ServicesListType | ServiceConnectionType | ConnectionSettingType | CustomerSupportType);
+export type MyAccountOpenServiceUrlOptions = ConfigsOptionsWithoutIsNewTab & { view: LoginLinkTo };
+export type LinkKitOpenServiceUrlOptions = ConfigsOptionsWithoutIsNewTab;
+export type OpenServiceUrlOptions =
+  | VaultOpenServiceUrlOptions
+  | MyAccountOpenServiceUrlOptions
+  | LinkKitOpenServiceUrlOptions;
 
 export type Scopes = string | string[];
 
@@ -109,10 +115,9 @@ export type OnboardOptions = Omit<
 
 export type OnboardUrlOptions = Omit<OnboardOptions, 'isNewTab'>;
 
-export type ServiceId = string | 'vault' | 'myaccount' | 'linkkit';
+export type ServiceId = 'vault' | 'myaccount' | 'link-kit';
 
 export type LoginLinkTo =
-  | string
   | 'settings'
   | 'settings/authorized-applications'
   | 'settings/change-language'


### PR DESCRIPTION
Currently APIs such as `authorize`, `onboard`, `logout` and `openService` will open a generated URL immediately on API call.

Introduce equivalent new API for these existing APIs to get the generated URL instead of calling them on the fly.

- Also update doc
- Typings
- Remove email as mandatory value for `onboard` API.