### PR TITLE
[LINK-4184] Store `code_verifier` in `localStorage` 

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -10,11 +10,11 @@ describe('storage', () => {
   });
 
   test('get with invalid existing storage value', () => {
-    window.sessionStorage.setItem(STORE_KEY, '"abc"');
+    window.localStorage.setItem(STORE_KEY, '"abc"');
 
     expect(get('key1')).toBeUndefined();
 
-    window.sessionStorage.setItem(STORE_KEY, '');
+    window.localStorage.setItem(STORE_KEY, '');
 
     expect(get('key1')).toBeUndefined();
   });

--- a/src/api/exchange-token.ts
+++ b/src/api/exchange-token.ts
@@ -64,6 +64,7 @@ export default async function exchangeToken(
       throw new Error(result.error_description);
     }
 
+    storage.del('cv');
     return result as Token;
   } catch (error) {
     throw new Error(`[mt-link-sdk] \`exchangeToken\` execution failed. ${error}`);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,9 +1,9 @@
 export const STORE_KEY = 'mt-link-javascript-sdk';
 
-const sessionStorage = window.sessionStorage;
+const localStorage = window.localStorage;
 
 function getStorageObject(): { [key: string]: string } {
-  const stringifiedData = sessionStorage.getItem(STORE_KEY) || '';
+  const stringifiedData = localStorage.getItem(STORE_KEY) || '';
   let data = {};
 
   try {
@@ -23,14 +23,14 @@ export function set(key: string, value: string): void {
   const data = getStorageObject();
   data[key] = value;
 
-  sessionStorage.setItem(STORE_KEY, JSON.stringify(data));
+  localStorage.setItem(STORE_KEY, JSON.stringify(data));
 }
 
 export function del(key: string): void {
   const data = getStorageObject();
   delete data[key];
 
-  sessionStorage.setItem(STORE_KEY, JSON.stringify(data));
+  localStorage.setItem(STORE_KEY, JSON.stringify(data));
 }
 
 export default {


### PR DESCRIPTION
As decided in the [ADR](https://moneytree-app.atlassian.net/wiki/spaces/LPT/pages/2668363940/ADR+JS+SDK+cross-tab+storage)

- **Replace `sessionStorage` with `localStorage`**
- **Clean up `cv` in `localStorage` after `exchangeToken` succeeds**
