### PR TITLE
[PMB-1165] Add `affiliate_code` in authorize url

### DIFF
--- a/src/api/__tests__/authorize-url.test.ts
+++ b/src/api/__tests__/authorize-url.test.ts
@@ -96,5 +96,66 @@ describe('api', () => {
       }
       expectUrlToMatchWithPKCE(url, {baseUrl: MY_ACCOUNT_DOMAINS.production, path: '/oauth/authorize', query})
     });
+
+    test('includes affiliate_code when provided', () => {
+      mockedStorage.set.mockClear();
+    
+      const state = 'state';
+      const scopes = 'points_read';
+      const affiliateCode = 'mtb_hoge';
+    
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { redirectUri });
+    
+      const url = authorizeUrl(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode
+      });
+      
+      const urlObj = new URL(url);
+      expect(urlObj.searchParams.get('affiliate_code')).toBe(affiliateCode);
+    });   
+    
+    test('does not include affiliate_code when affiliateCode is undefined', () => {
+      mockedStorage.set.mockClear();
+    
+      const state = 'state';
+      const scopes = 'points_read';
+    
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { redirectUri });
+    
+      const url = authorizeUrl(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode: undefined
+      });
+    
+      const urlObj = new URL(url);
+      expect(urlObj.searchParams.has('affiliate_code')).toBe(false);
+    });
+
+    test('does not include affiliate_code when affiliateCode is empty string', () => {
+      mockedStorage.set.mockClear();
+    
+      const state = 'state';
+      const scopes = 'points_read';
+    
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { redirectUri });
+    
+      const url = authorizeUrl(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode: null as any
+      });
+      
+      const urlObj = new URL(url);
+      expect(urlObj.searchParams.has('affiliate_code')).toBe(false);
+    });    
   });
 });

--- a/src/api/__tests__/authorize.test.ts
+++ b/src/api/__tests__/authorize.test.ts
@@ -107,6 +107,87 @@ describe('api', () => {
       expectUrlToMatchWithPKCE(url, {baseUrl: MY_ACCOUNT_DOMAINS.production, path: '/oauth/authorize', query })
     });
 
+    test('includes affiliate_code when provided', () => {
+      mockedStorage.set.mockClear();
+      open.mockClear();
+
+      const state = 'state';
+      const scopes = 'points_read';
+      const samlSubjectId = 'mySubject';
+      const affiliateCode = 'mtb_hoge';
+
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { samlSubjectId });
+
+      authorize(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode
+      });
+
+      expect(open).toBeCalledTimes(1);
+      expect(open).toBeCalledWith(expect.any(String), '_self', 'noreferrer');
+      const url = open.mock.calls[0][0]
+
+      const parsed = new URL(url);
+      expect(parsed.searchParams.has('affiliate_code')).toBe(true);
+    });
+
+    test('does not include affiliate_code when affiliateCode is undefined', () => {
+      mockedStorage.set.mockClear();
+      open.mockClear();
+
+      const state = 'state';
+      const scopes = 'points_read';
+      const samlSubjectId = 'mySubject';
+      const affiliateCode = undefined;
+
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { samlSubjectId });
+
+      authorize(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode
+      });
+
+      expect(open).toBeCalledTimes(1);
+      expect(open).toBeCalledWith(expect.any(String), '_self', 'noreferrer');
+      const url = open.mock.calls[0][0]
+
+      const parsed = new URL(url);
+      expect(parsed.searchParams.has('affiliate_code')).toBe(false);
+    });
+
+    test('does not include affiliate_code when affiliateCode is null', () => {
+      mockedStorage.set.mockClear();
+      open.mockClear();
+
+      const state = 'state';
+      const scopes = 'points_read';
+      const samlSubjectId = 'mySubject';
+      const affiliateCode = null as any;
+
+      const mtLinkSdk = new MtLinkSdk();
+      mtLinkSdk.init(clientId, { samlSubjectId });
+
+      authorize(mtLinkSdk.storedOptions, {
+        state,
+        redirectUri,
+        scopes,
+        affiliateCode
+      });
+
+      expect(open).toBeCalledTimes(1);
+      expect(open).toBeCalledWith(expect.any(String), '_self', 'noreferrer');
+      const url = open.mock.calls[0][0]
+
+      const parsed = new URL(url);
+      expect(parsed.searchParams.has('affiliate_code')).toBe(false);
+    });
+
     test('without window', () => {
       const windowSpy = jest.spyOn(global, 'window', 'get');
       // @ts-ignore: mocking window object to undefined

--- a/src/api/authorize-url.ts
+++ b/src/api/authorize-url.ts
@@ -20,7 +20,7 @@ export default function authorize(storedOptions: StoredOptions, options: Authori
     throw new Error('[mt-link-sdk] Make sure to call `init` before calling `authorizeUrl/authorize`.');
   }
 
-  const { scopes = defaultScopes, redirectUri = defaultRedirectUri, codeChallenge, state, ...rest } = options;
+  const { scopes = defaultScopes, redirectUri = defaultRedirectUri, codeChallenge, state, affiliateCode, ...rest } = options;
 
   if (!redirectUri) {
     throw new Error(
@@ -44,7 +44,8 @@ export default function authorize(storedOptions: StoredOptions, options: Authori
     country: 'JP',
     locale,
     saml_subject_id: samlSubjectId,
-    configs: generateConfigs(mergeConfigs(storedOptions, rest))
+    configs: generateConfigs(mergeConfigs(storedOptions, rest)),
+    ...(affiliateCode ? { affiliate_code: affiliateCode } : {})
   });
 
   return `${MY_ACCOUNT_DOMAINS[mode]}/oauth/authorize?${queryString}`;

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -233,8 +233,15 @@ export interface OAuthSharedParams {
    */
   redirectUri?: string;
 }
-
-export interface AuthorizeOptions extends OAuthSharedParams, ConfigsOptions, AuthorizeConfigsOptions {
+export interface AffiliateTrackingParams {
+  /**
+   * An optional affiliate code for attributing user referrals.
+   *
+   * If not provided, no affiliate attribution will be applied.
+   */
+  affiliateCode?: string;
+}
+export interface AuthorizeOptions extends OAuthSharedParams, ConfigsOptions, AuthorizeConfigsOptions, AffiliateTrackingParams {
   /**
    * Access scopes you're requesting. This can be a single scope, or an array of scopes.
    *


### PR DESCRIPTION
### Summary
This PR adds support for tracking affiliate attribution by introducing an optional `affiliateCode` parameter to the OAuth authorize flow.

This PR is part of PMB-1068

