### PR TITLE
[LON-142] feat(storage): use sessionStorage when localStorage is not available

### DIFF
--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -1,21 +1,58 @@
-import { set, get, STORE_KEY } from '../storage';
+import { set, get, del, STORE_KEY } from '../storage';
+
+function clearStorage() {
+  window.localStorage.removeItem(STORE_KEY);
+  window.sessionStorage.removeItem(STORE_KEY);
+}
 
 describe('storage', () => {
+  beforeEach(() => {
+    clearStorage();
+  });
+
+  test('falls back to sessionStorage if localStorage is unavailable', () => {
+    const originalLocalStorage = window.localStorage;
+    // @ts-ignore, Suppress TypeScript error when deleting window.localStorage for test simulation.
+    delete window.localStorage;
+    window.sessionStorage.setItem(STORE_KEY, JSON.stringify({ key1: 'value1' }));
+    expect(get('key1')).toBe('value1');
+    window.localStorage = originalLocalStorage;
+  });
+
+  test('throws if neither storage is available', () => {
+    const originalLocalStorage = window.localStorage;
+    const originalSessionStorage = window.sessionStorage;
+    // @ts-ignore, Suppress TypeScript error when deleting window.localStorage for test simulation.
+    delete window.localStorage;
+    // @ts-ignore, Suppress TypeScript error when deleting window.sessionStorage for test simulation.
+    delete window.sessionStorage;
+    expect(() => get('key1')).toThrow('Neither localStorage nor sessionStorage is available');
+    window.localStorage = originalLocalStorage;
+    window.sessionStorage = originalSessionStorage;
+  });
+
+  test('getStorageObject throws if storage contains invalid JSON', () => {
+    window.localStorage.setItem(STORE_KEY, '{invalid json}');
+    expect(() => get('key1')).toThrow('Failed to retrieve mt-link-javascript-sdk data from storage');
+  });
+
   test('set, get', () => {
     expect(get('key1')).toBeUndefined();
-
     set('key1', 'value1');
-
     expect(get('key1')).toBe('value1');
   });
 
   test('get with invalid existing storage value', () => {
     window.localStorage.setItem(STORE_KEY, '"abc"');
-
     expect(get('key1')).toBeUndefined();
-
     window.localStorage.setItem(STORE_KEY, '');
+    expect(get('key1')).toBeUndefined();
+  });
 
+  test('delete removes key', () => {
+    set('key1', 'value1');
+    expect(get('key1')).toBe('value1');
+    del('key1');
     expect(get('key1')).toBeUndefined();
   });
 });

--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -31,9 +31,9 @@ describe('storage', () => {
     window.sessionStorage = originalSessionStorage;
   });
 
-  test('getStorageObject throws if storage contains invalid JSON', () => {
+  test('returns undefined if storage contains invalid JSON', () => {
     window.localStorage.setItem(STORE_KEY, '{invalid json}');
-    expect(() => get('key1')).toThrow('Failed to retrieve mt-link-javascript-sdk data from storage');
+    expect(get('key1')).toBeUndefined();
   });
 
   test('set, get', () => {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,18 +1,39 @@
 export const STORE_KEY = 'mt-link-javascript-sdk';
 
-const localStorage = window.localStorage;
+interface StorageData {
+  [key: string]: string;
+}
 
-function getStorageObject(): { [key: string]: string } {
-  const stringifiedData = localStorage.getItem(STORE_KEY) || '';
-  let data = {};
+function getAvailableStorage(): Storage {
+  if (typeof window.localStorage !== 'undefined' && window.localStorage !== null) return window.localStorage;
+
+  // Fallback to sessionStorage
+  if (typeof window.sessionStorage !== 'undefined' && window.sessionStorage !== null) return window.sessionStorage;
+
+  throw new Error('Neither localStorage nor sessionStorage is available');
+}
+
+function getStorageObject(): StorageData {
+  const storage = getAvailableStorage();
 
   try {
-    data = JSON.parse(stringifiedData);
-  } catch (error) {
-    data = {};
-  }
+    const stringifiedData = storage.getItem(STORE_KEY);
+    if (!stringifiedData) return {};
 
-  return data;
+    return JSON.parse(stringifiedData);
+  } catch (error) {
+    throw new Error(`Failed to retrieve ${STORE_KEY} data from storage`);
+  }
+}
+
+function saveStorageObject(data: StorageData): void {
+  const storage = getAvailableStorage();
+
+  try {
+    storage.setItem(STORE_KEY, JSON.stringify(data));
+  } catch (error) {
+    throw new Error('Failed to save data to storage');
+  }
 }
 
 export function get(key: string): string | undefined {
@@ -23,14 +44,14 @@ export function set(key: string, value: string): void {
   const data = getStorageObject();
   data[key] = value;
 
-  localStorage.setItem(STORE_KEY, JSON.stringify(data));
+  saveStorageObject(data);
 }
 
 export function del(key: string): void {
   const data = getStorageObject();
   delete data[key];
 
-  localStorage.setItem(STORE_KEY, JSON.stringify(data));
+  saveStorageObject(data);
 }
 
 export default {


### PR DESCRIPTION
On Android WebView, localStorage is only available when the correct configuration is enabled. 
In the long term, we want all clients to consistently use `localStorage`, but in the short term, we need to support both `localStorage` and `sessionStorage` to avoid breaking existing client apps


- Added a new function `getAvailableStorage` to determine which storage is available, giving `localStorage` higher priority than `sessionStorage` 
- Throwing out an Error when both storage not avalible which we don't expect that would happen
- functions `saveStorageObject` to handle save data into avaliable storage
- functions `getStorageObject` to handle retreive data from avaliable storage