### PR TITLE
chore(docs): remove duplicate changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,52 +9,26 @@
 ## 4.2.0 (2025-04-18)
 
 * added affiliate_code in authorize url ([129e607](https://github.com/moneytree/mt-link-javascript-sdk/commit/129e607))
-* Clean up `cv` in `localStorage` after `exchangeToken` succeeds ([32e8fbf](https://github.com/moneytree/mt-link-javascript-sdk/commit/32e8fbf))
-* Fix `authnMethod` typo in docs ([3287d10](https://github.com/moneytree/mt-link-javascript-sdk/commit/3287d10))
-* fix(docs) fix broken hyperlink ([471583b](https://github.com/moneytree/mt-link-javascript-sdk/commit/471583b))
-* Replace `sessionStorage` with `localStorage` ([6602ea2](https://github.com/moneytree/mt-link-javascript-sdk/commit/6602ea2))
 * Setup Dependabot ([64e4b55](https://github.com/moneytree/mt-link-javascript-sdk/commit/64e4b55))
 * fix(config): run npm pkg fix ([22873e2](https://github.com/moneytree/mt-link-javascript-sdk/commit/22873e2))
 * docs: update version bump instructions in readme ([06c5f1e](https://github.com/moneytree/mt-link-javascript-sdk/commit/06c5f1e))
-* chore(ci): Fix linting job in CircleCI ([f1b4812](https://github.com/moneytree/mt-link-javascript-sdk/commit/f1b4812))
-* chore(lint): Ignore auto-generated doc files when linting with eslint ([cc244c6](https://github.com/moneytree/mt-link-javascript-sdk/commit/cc244c6))
-* chore(release): bump to version 4.1.0 :tada: ([84db1ae](https://github.com/moneytree/mt-link-javascript-sdk/commit/84db1ae))
-* chore(release): bump to version 4.1.1 :tada: ([00f7c29](https://github.com/moneytree/mt-link-javascript-sdk/commit/00f7c29))
-* build(deps): bump @babel/traverse from 7.10.5 to 7.23.2 ([1d08d4c](https://github.com/moneytree/mt-link-javascript-sdk/commit/1d08d4c))
-* build(deps): bump browserify-sign from 4.2.1 to 4.2.2 ([6e35321](https://github.com/moneytree/mt-link-javascript-sdk/commit/6e35321))
-* build(deps): bump browserify-sign from 4.2.1 to 4.2.2 in /sample ([ffc6d2a](https://github.com/moneytree/mt-link-javascript-sdk/commit/ffc6d2a))
-* build(deps): bump docsify from 4.12.1 to 4.13.1 ([2e2e12c](https://github.com/moneytree/mt-link-javascript-sdk/commit/2e2e12c))
-* build(deps): bump dompurify from 2.2.7 to 2.5.7 ([5c49346](https://github.com/moneytree/mt-link-javascript-sdk/commit/5c49346))
 * build(deps): bump elliptic from 6.5.4 to 6.6.0 ([254fdbc](https://github.com/moneytree/mt-link-javascript-sdk/commit/254fdbc))
-* build(deps): bump express from 4.18.2 to 4.21.1 in /sample ([815245a](https://github.com/moneytree/mt-link-javascript-sdk/commit/815245a))
-* build(deps): bump follow-redirects from 1.14.8 to 1.15.9 in /sample ([6eedb71](https://github.com/moneytree/mt-link-javascript-sdk/commit/6eedb71))
 * build(deps): bump serve-static from 1.14.1 to 1.16.2 ([1043b28](https://github.com/moneytree/mt-link-javascript-sdk/commit/1043b28))
-* feat(sdk): Add option to open vault directly in the update and delete connection view ([0a5d61d](https://github.com/moneytree/mt-link-javascript-sdk/commit/0a5d61d))
 
 
 
 ## <small>4.1.1 (2025-03-04)</small>
 
+* chore(release): bump to version 4.1.1 :tada: ([00f7c29](https://github.com/moneytree/mt-link-javascript-sdk/commit/00f7c29))
 * Clean up `cv` in `localStorage` after `exchangeToken` succeeds ([32e8fbf](https://github.com/moneytree/mt-link-javascript-sdk/commit/32e8fbf))
-* Fix `authnMethod` typo in docs ([3287d10](https://github.com/moneytree/mt-link-javascript-sdk/commit/3287d10))
-* fix(docs) fix broken hyperlink ([471583b](https://github.com/moneytree/mt-link-javascript-sdk/commit/471583b))
 * Replace `sessionStorage` with `localStorage` ([6602ea2](https://github.com/moneytree/mt-link-javascript-sdk/commit/6602ea2))
-* chore(ci): Fix linting job in CircleCI ([f1b4812](https://github.com/moneytree/mt-link-javascript-sdk/commit/f1b4812))
-* chore(lint): Ignore auto-generated doc files when linting with eslint ([cc244c6](https://github.com/moneytree/mt-link-javascript-sdk/commit/cc244c6))
-* chore(release): bump to version 4.1.0 :tada: ([84db1ae](https://github.com/moneytree/mt-link-javascript-sdk/commit/84db1ae))
-* feat(sdk): Add option to open vault directly in the update and delete connection view ([0a5d61d](https://github.com/moneytree/mt-link-javascript-sdk/commit/0a5d61d))
-* build(deps): bump @babel/traverse from 7.10.5 to 7.23.2 ([1d08d4c](https://github.com/moneytree/mt-link-javascript-sdk/commit/1d08d4c))
-* build(deps): bump browserify-sign from 4.2.1 to 4.2.2 ([6e35321](https://github.com/moneytree/mt-link-javascript-sdk/commit/6e35321))
-* build(deps): bump browserify-sign from 4.2.1 to 4.2.2 in /sample ([ffc6d2a](https://github.com/moneytree/mt-link-javascript-sdk/commit/ffc6d2a))
-* build(deps): bump docsify from 4.12.1 to 4.13.1 ([2e2e12c](https://github.com/moneytree/mt-link-javascript-sdk/commit/2e2e12c))
-* build(deps): bump dompurify from 2.2.7 to 2.5.7 ([5c49346](https://github.com/moneytree/mt-link-javascript-sdk/commit/5c49346))
-* build(deps): bump express from 4.18.2 to 4.21.1 in /sample ([815245a](https://github.com/moneytree/mt-link-javascript-sdk/commit/815245a))
-* build(deps): bump follow-redirects from 1.14.8 to 1.15.9 in /sample ([6eedb71](https://github.com/moneytree/mt-link-javascript-sdk/commit/6eedb71))
+* Fix `authnMethod` typo in docs ([3287d10](https://github.com/moneytree/mt-link-javascript-sdk/commit/3287d10))
 
 
 
 ## 4.1.0 (2024-10-23)
 
+* chore(release): bump to version 4.1.0 :tada: ([84db1ae](https://github.com/moneytree/mt-link-javascript-sdk/commit/84db1ae))
 * chore(ci): Fix linting job in CircleCI ([f1b4812](https://github.com/moneytree/mt-link-javascript-sdk/commit/f1b4812))
 * chore(lint): Ignore auto-generated doc files when linting with eslint ([cc244c6](https://github.com/moneytree/mt-link-javascript-sdk/commit/cc244c6))
 * feat(sdk): Add option to open vault directly in the update and delete connection view ([0a5d61d](https://github.com/moneytree/mt-link-javascript-sdk/commit/0a5d61d))
@@ -248,3 +222,4 @@ one via the APIs' options parameter if you need one.
 ### Features
 
 * creating a JS SDK ([333cf8c](https://github.com/moneytree/mt-link-javascript-sdk/commit/333cf8c36f7a8299c2bccf441454b04d31e7d907))
+


### PR DESCRIPTION
We ended up with some duplicate changelog entries, this cleans them up.