### PR TITLE
[LON-203] feat(vault): add showBackBarOn option to control go back bar visibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - *attach_workspace
       - run:
           name: Running tests
-          command: yarn test
+          command: yarn test --maxWorkers=2
 
   done:
     <<: *docker_defaults

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,29 @@ mtLinkSdk.openService('vault', { view: 'services-list' });
 
 Vault has several different views with different options for each, view the full documentation [here](types/classes/MtLinkSdk.html#openService.openService-3 ':ignore').
 
+##### `showBackBarOn` (Vault only)
+
+Use the `showBackBarOn` option to show the back bar button on specific Vault pages.
+
+```javascript
+// services-list
+mtLinkSdk.openService('vault', {
+  showBackBarOn: { view: 'services-list' }
+});
+
+// connection-setting — requires credentialId
+mtLinkSdk.openService('vault', {
+  showBackBarOn: { view: 'connection-setting', credentialId: '123' }
+});
+
+// service-connection — requires entityKey
+mtLinkSdk.openService('vault', {
+  showBackBarOn: { view: 'service-connection', entityKey: 'bank_xyz' }
+});
+```
+
+> **Note:** This option only has an effect on mobile viewport sizes. On desktop, the back bar button is always visible regardless of this setting.
+
 #### Open MyAccount
 
 ```javascript

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,10 +158,6 @@ mtLinkSdk.openService('vault', {
   showBackBarOn: { view: 'connection-setting', credentialId: '123' }
 });
 
-// service-connection — requires entityKey
-mtLinkSdk.openService('vault', {
-  showBackBarOn: { view: 'service-connection', entityKey: 'bank_xyz' }
-});
 ```
 
 > **Note:** This option only has an effect on mobile viewport sizes. On desktop, the back bar button is always visible regardless of this setting.

--- a/sample/src/elements.ts
+++ b/sample/src/elements.ts
@@ -22,7 +22,9 @@ export default {
     group: document.getElementById('open-service-options-group') as HTMLSelectElement,
     search: document.getElementById('open-service-options-search') as HTMLInputElement,
     entityKey: document.getElementById('open-service-options-entityKey') as HTMLInputElement,
-    credentialId: document.getElementById('open-service-options-credentialId') as HTMLInputElement
+    credentialId: document.getElementById('open-service-options-credentialId') as HTMLInputElement,
+    showBackBarOn: document.getElementById('open-service-options-showBackBarOn') as HTMLSelectElement,
+    showBackBarOnCredentialId: document.getElementById('open-service-options-showBackBarOn-credentialId') as HTMLInputElement
   },
   initializeBtn: document.getElementById('initialize-btn') as HTMLButtonElement,
   authorizeBtn: document.getElementById('authorize-btn') as HTMLButtonElement,

--- a/sample/src/index.html
+++ b/sample/src/index.html
@@ -273,6 +273,21 @@
               <input id="open-service-options-credentialId" type="text" placeholder="credentialId" />
             </div>
           </div>
+
+          <div id="show-back-bar-on-options">
+            <p>showBackBarOn, <small>Show the back bar button on a specific Vault page (mobile only).</small></p>
+            <div>
+              <select id="open-service-options-showBackBarOn">
+                <option value="" default>select view</option>
+                <option value="services-list">services-list</option>
+                <option value="connection-setting">connection-setting</option>
+              </select>
+            </div>
+            <div id="show-back-bar-on-connection-setting" style="display: none">
+              <p>credentialId, <small>Show back bar on this connection setting page.</small></p>
+              <input id="open-service-options-showBackBarOn-credentialId" type="text" placeholder="credentialId" />
+            </div>
+          </div>
         </div>
 
         <a href="#common-options"><h4>Common API options(optionals)</h4></a>

--- a/sample/src/index.ts
+++ b/sample/src/index.ts
@@ -6,8 +6,8 @@ import mtLinkSdk, {
   VaultOpenServiceViewServiceList,
   VaultOpenServiceViewServiceConnection,
   VaultOpenServiceViewConnectionSetting,
-  MyAccountOpenServiceOptions,
   VaultOpenServiceViewCustomerSupport,
+  VaultSpecificOptions,
   ServiceId,
   LoginLinkTo,
   VaultViewServiceList
@@ -115,9 +115,17 @@ elements.logoutBtn.onclick = () => {
 
 // Launch open service
 elements.openServiceBtn.onclick = () => {
-  const { openServiceOptionsElms } = elements;
+  const { openServiceOptionsElms, commonOptionsElms } = elements;
   const serviceId: ServiceId = openServiceOptionsElms.serviceId.options[openServiceOptionsElms.serviceId.selectedIndex]
     .value as ServiceId;
+
+  const commonOptions = {
+    ...(commonOptionsElms.backTo.value ? { backTo: commonOptionsElms.backTo.value } : {}),
+    ...(commonOptionsElms.email.value ? { email: commonOptionsElms.email.value } : {}),
+    isNewTab: commonOptionsElms.isNewTab.checked,
+    showRememberMe: commonOptionsElms.showRememberMe.checked,
+    showAuthToggle: commonOptionsElms.showAuthToggle.checked
+  };
 
   if (serviceId === 'vault') {
     type VaultOptions =
@@ -126,6 +134,22 @@ elements.openServiceBtn.onclick = () => {
       | VaultOpenServiceViewServiceList
       | VaultOpenServiceViewCustomerSupport;
     let openServicesOptions: VaultOptions = {} as VaultOptions;
+
+    const getShowBackBarOn = (): VaultSpecificOptions['showBackBarOn'] => {
+      const selectedView =
+        openServiceOptionsElms.showBackBarOn.options[openServiceOptionsElms.showBackBarOn.selectedIndex].value;
+
+      switch (selectedView) {
+        case 'services-list':
+          return { view: 'services-list' };
+        case 'connection-setting':
+          return { view: 'connection-setting', credentialId: openServiceOptionsElms.showBackBarOnCredentialId.value };
+        default:
+          return undefined;
+      }
+    };
+    const showBackBarOn = getShowBackBarOn();
+
     const view = openServiceOptionsElms.vaultView.options[openServiceOptionsElms.vaultView.selectedIndex].value as
       | 'services-list'
       | 'service-connection'
@@ -146,26 +170,30 @@ elements.openServiceBtn.onclick = () => {
               VaultViewServiceList,
               'group'
             >['group']) || undefined,
-          search: openServiceOptionsElms.search.value || undefined
+          search: openServiceOptionsElms.search.value || undefined,
+          showBackBarOn
         };
         break;
       case 'service-connection':
         openServicesOptions = {
           view: 'service-connection',
-          entityKey: openServiceOptionsElms.entityKey.value
+          entityKey: openServiceOptionsElms.entityKey.value,
+          showBackBarOn
         };
         break;
       case 'connection-setting':
         openServicesOptions = {
           view: 'connection-setting',
-          credentialId: openServiceOptionsElms.credentialId.value
+          credentialId: openServiceOptionsElms.credentialId.value,
+          showBackBarOn
         };
         break;
       case 'customer-support':
       default:
-        openServicesOptions = { view };
+        openServicesOptions = { view, showBackBarOn };
     }
-    mtLinkSdk.openService(serviceId, openServicesOptions);
+
+    mtLinkSdk.openService(serviceId, { ...commonOptions, ...openServicesOptions });
   }
 
   if (serviceId === 'myaccount') {
@@ -179,7 +207,7 @@ elements.openServiceBtn.onclick = () => {
       | 'settings/update-email'
       | 'settings/update-password';
 
-    mtLinkSdk.openService(serviceId, { view });
+    mtLinkSdk.openService(serviceId, { ...commonOptions, view });
   }
 };
 
@@ -234,6 +262,15 @@ elements.openServiceOptionsElms.vaultView.onchange = () => {
   if (optionsBlockElm) {
     optionsBlockElm.style.display = 'block';
   }
+};
+
+elements.openServiceOptionsElms.showBackBarOn.onchange = () => {
+  const { openServiceOptionsElms } = elements;
+  const selectedValue =
+    openServiceOptionsElms.showBackBarOn.options[openServiceOptionsElms.showBackBarOn.selectedIndex].value;
+
+  (document.getElementById('show-back-bar-on-connection-setting') as HTMLDivElement).style.display =
+    selectedValue === 'connection-setting' ? 'block' : 'none';
 };
 
 const initializeLinkSDK = (options: InitOptions = {}) => {

--- a/src/api/__tests__/open-service-url.test.ts
+++ b/src/api/__tests__/open-service-url.test.ts
@@ -177,6 +177,36 @@ describe('api', () => {
       expect(url).toBe(`${MY_ACCOUNT_DOMAINS.production}/?${query}`);
     });
 
+    test('vault with showBackBarOn services-list', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        showBackBarOn: { view: 'services-list' }
+      });
+
+      const query = qs.stringify({ configs: generateConfigs(), state: 'url=/services' });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
+    });
+
+    test('vault with showBackBarOn connection-setting', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        showBackBarOn: { view: 'connection-setting', credentialId: '123' }
+      });
+
+      const query = qs.stringify({ configs: generateConfigs(), state: 'url=/connection/123' });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
+    });
+
+    test('vault with showBackBarOn service-connection', () => {
+      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
+        showBackBarOn: { view: 'service-connection', entityKey: 'bank_xyz' }
+      });
+
+      const query = qs.stringify({ configs: generateConfigs(), state: 'url=/service/bank_xyz' });
+
+      expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
+    });
+
     test('invalid service id', () => {
       expect(() => {
         // force cast invalid value so that we can use it for testing

--- a/src/api/__tests__/open-service-url.test.ts
+++ b/src/api/__tests__/open-service-url.test.ts
@@ -197,16 +197,6 @@ describe('api', () => {
       expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
     });
 
-    test('vault with showBackBarOn service-connection', () => {
-      const url = openServiceUrl(new MtLinkSdk().storedOptions, 'vault', {
-        showBackBarOn: { view: 'service-connection', entityKey: 'bank_xyz' }
-      });
-
-      const query = qs.stringify({ configs: generateConfigs(), state: 'url=/service/bank_xyz' });
-
-      expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
-    });
-
     test('invalid service id', () => {
       expect(() => {
         // force cast invalid value so that we can use it for testing

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -12,7 +12,8 @@ import {
   MyAccountServiceTypes,
   LinkKitOpenServiceUrlOptions,
   MyAccountOpenServiceUrlOptions,
-  ConfigsOptionsWithoutIsNewTab,
+  VaultOpenServiceUrlOptions,
+  VaultSpecificOptions,
   VaultOpenServiceUrlViewServiceList,
   VaultOpenServiceUrlViewServiceConnection,
   VaultOpenServiceUrlViewConnectionSetting,
@@ -27,6 +28,7 @@ interface QueryData {
   locale?: string;
   configs: string;
   saml_subject_id?: string;
+  state?: string;
 }
 
 export default function openServiceUrl(
@@ -42,7 +44,7 @@ export default function openServiceUrl(
 export default function openServiceUrl(
   storedOptions: StoredOptions,
   serviceId: 'vault',
-  options?: ConfigsOptionsWithoutIsNewTab
+  options?: VaultOpenServiceUrlOptions
 ): string;
 export default function openServiceUrl(
   storedOptions: StoredOptions,
@@ -81,13 +83,27 @@ export default function openServiceUrl(
 ): string {
   const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
 
+  const toVaultStateParam = (value: NonNullable<VaultSpecificOptions['showBackBarOn']>): string => {
+    switch (value.view) {
+      case 'services-list':
+        return 'url=/services';
+      case 'connection-setting':
+        return `url=/connection/${value.credentialId}`;
+      case 'service-connection':
+        return `url=/service/${value.entityKey}`;
+    }
+  };
+
   const getQueryValue = (needStringify = true): string | QueryData => {
+    const vaultShowBackBarOn = serviceId === 'vault' && 'showBackBarOn' in options && options.showBackBarOn;
+
     const query: QueryData = {
       client_id: clientId,
       cobrand_client_id: cobrandClientId,
       locale,
       saml_subject_id: samlSubjectId,
-      configs: generateConfigs(mergeConfigs(storedOptions, options))
+      configs: generateConfigs(mergeConfigs(storedOptions, options)),
+      state: vaultShowBackBarOn ? toVaultStateParam(vaultShowBackBarOn) : undefined
     };
 
     if (!needStringify) {

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -89,8 +89,6 @@ export default function openServiceUrl(
         return 'url=/services';
       case 'connection-setting':
         return `url=/connection/${value.credentialId}`;
-      case 'service-connection':
-        return `url=/service/${value.entityKey}`;
     }
   };
 

--- a/src/api/open-service.ts
+++ b/src/api/open-service.ts
@@ -5,13 +5,13 @@ import {
   OpenServiceOptions,
   LinkKitOpenServiceOptions,
   MyAccountOpenServiceOptions,
+  VaultOpenServiceOptions,
   VaultOpenServiceViewServiceList,
   VaultOpenServiceViewServiceConnection,
   VaultOpenServiceViewConnectionSetting,
   VaultOpenServiceViewConnectionUpdate,
   VaultOpenServiceViewConnectionDelete,
   VaultOpenServiceViewCustomerSupport,
-  ConfigsOptions
 } from '../typings';
 import openServiceUrl from './open-service-url';
 
@@ -25,7 +25,7 @@ export default function openService(
   serviceId: 'myaccount',
   options?: MyAccountOpenServiceOptions
 ): void;
-export default function openService(storedOptions: StoredOptions, serviceId: 'vault', options?: ConfigsOptions): void;
+export default function openService(storedOptions: StoredOptions, serviceId: 'vault', options?: VaultOpenServiceOptions): void;
 export default function openService(
   storedOptions: StoredOptions,
   serviceId: 'vault',

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ import {
   MyAccountOpenServiceOptions,
   OpenServiceOptions,
   ConfigsOptions,
-  ConfigsOptionsWithoutIsNewTab,
+  VaultOpenServiceOptions,
+  VaultOpenServiceUrlOptions,
   VaultOpenServiceUrlViewServiceList,
   VaultOpenServiceUrlViewServiceConnection,
   VaultOpenServiceUrlViewConnectionSetting,
@@ -213,7 +214,7 @@ export class MtLinkSdk {
    *
    * @remark ⚠️ calling this API before calling {@link init} will open the services view without branding (company logo etc.)
    */
-  public openService(serviceId: 'vault', options?: ConfigsOptions): void;
+  public openService(serviceId: 'vault', options?: VaultOpenServiceOptions): void;
   public openService(serviceId: 'vault', options?: VaultOpenServiceViewServiceList): void;
   public openService(serviceId: 'vault', options?: VaultOpenServiceViewServiceConnection): void;
   public openService(serviceId: 'vault', options?: VaultOpenServiceViewConnectionSetting): void;
@@ -242,7 +243,7 @@ export class MtLinkSdk {
    */
   public openServiceUrl(serviceId: 'link-kit', options?: LinkKitOpenServiceUrlOptions): string;
   public openServiceUrl(serviceId: 'myaccount', options?: MyAccountOpenServiceUrlOptions): string;
-  public openServiceUrl(serviceId: 'vault', options?: ConfigsOptionsWithoutIsNewTab): string;
+  public openServiceUrl(serviceId: 'vault', options?: VaultOpenServiceUrlOptions): string;
   public openServiceUrl(serviceId: 'vault', options?: VaultOpenServiceUrlViewServiceList): string;
   public openServiceUrl(serviceId: 'vault', options?: VaultOpenServiceUrlViewServiceConnection): string;
   public openServiceUrl(serviceId: 'vault', options?: VaultOpenServiceUrlViewConnectionSetting): string;

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -167,13 +167,12 @@ export interface VaultSpecificOptions {
    * Supported views:
    * - `{ view: 'services-list' }`
    * - `{ view: 'connection-setting', credentialId: string }`
-   * - `{ view: 'service-connection', entityKey: string }`
    *
    * @remarks
    * This option only has an effect on mobile viewport sizes.
    * On desktop, the back bar button is always visible regardless of this setting.
    */
-  showBackBarOn?: Pick<VaultViewServiceList, 'view'> | VaultViewConnectionSetting | VaultViewServiceConnection;
+  showBackBarOn?: Pick<VaultViewServiceList, 'view'> | VaultViewConnectionSetting;
 }
 
 export type MyAccountServiceTypes = {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -160,6 +160,22 @@ export type VaultServiceTypes =
   | VaultViewConnectionDelete
   | VaultViewCustomerSupport;
 
+export interface VaultSpecificOptions {
+  /**
+   * Show the back bar button when the guest is on a specific Vault page.
+   *
+   * Supported views:
+   * - `{ view: 'services-list' }`
+   * - `{ view: 'connection-setting', credentialId: string }`
+   * - `{ view: 'service-connection', entityKey: string }`
+   *
+   * @remarks
+   * This option only has an effect on mobile viewport sizes.
+   * On desktop, the back bar button is always visible regardless of this setting.
+   */
+  showBackBarOn?: Pick<VaultViewServiceList, 'view'> | VaultViewConnectionSetting | VaultViewServiceConnection;
+}
+
 export type MyAccountServiceTypes = {
   /**
    * Directly go to the chosen page. Currently supported locations include:
@@ -175,25 +191,28 @@ export type MyAccountOpenServiceUrlOptions =
   | ConfigsOptionsWithoutIsNewTab
   | (ConfigsOptionsWithoutIsNewTab & MyAccountServiceTypes);
 
-export type VaultOpenServiceViewServiceList = ConfigsOptions & VaultViewServiceList;
-export type VaultOpenServiceViewServiceConnection = ConfigsOptions & VaultViewServiceConnection;
-export type VaultOpenServiceViewConnectionSetting = ConfigsOptions & VaultViewConnectionSetting;
-export type VaultOpenServiceViewConnectionUpdate = ConfigsOptions & VaultViewConnectionUpdate;
-export type VaultOpenServiceViewConnectionDelete = ConfigsOptions & VaultViewConnectionDelete;
-export type VaultOpenServiceViewCustomerSupport = ConfigsOptions & VaultViewCustomerSupport;
-export type VaultOpenServiceUrlViewServiceList = ConfigsOptionsWithoutIsNewTab & VaultViewServiceList;
-export type VaultOpenServiceUrlViewServiceConnection = ConfigsOptionsWithoutIsNewTab & VaultViewServiceConnection;
-export type VaultOpenServiceUrlViewConnectionSetting = ConfigsOptionsWithoutIsNewTab & VaultViewConnectionSetting;
-export type VaultOpenServiceUrlViewConnectionUpdate = ConfigsOptionsWithoutIsNewTab & VaultViewConnectionUpdate;
-export type VaultOpenServiceUrlViewConnectionDelete = ConfigsOptionsWithoutIsNewTab & VaultViewConnectionDelete;
-export type VaultOpenServiceUrlViewCustomerSupport = ConfigsOptionsWithoutIsNewTab & VaultViewCustomerSupport;
+export type VaultOpenServiceOptions = ConfigsOptions & VaultSpecificOptions;
+export type VaultOpenServiceUrlOptions = ConfigsOptionsWithoutIsNewTab & VaultSpecificOptions;
+
+export type VaultOpenServiceViewServiceList = VaultOpenServiceOptions & VaultViewServiceList;
+export type VaultOpenServiceViewServiceConnection = VaultOpenServiceOptions & VaultViewServiceConnection;
+export type VaultOpenServiceViewConnectionSetting = VaultOpenServiceOptions & VaultViewConnectionSetting;
+export type VaultOpenServiceViewConnectionUpdate = VaultOpenServiceOptions & VaultViewConnectionUpdate;
+export type VaultOpenServiceViewConnectionDelete = VaultOpenServiceOptions & VaultViewConnectionDelete;
+export type VaultOpenServiceViewCustomerSupport = VaultOpenServiceOptions & VaultViewCustomerSupport;
+export type VaultOpenServiceUrlViewServiceList = VaultOpenServiceUrlOptions & VaultViewServiceList;
+export type VaultOpenServiceUrlViewServiceConnection = VaultOpenServiceUrlOptions & VaultViewServiceConnection;
+export type VaultOpenServiceUrlViewConnectionSetting = VaultOpenServiceUrlOptions & VaultViewConnectionSetting;
+export type VaultOpenServiceUrlViewConnectionUpdate = VaultOpenServiceUrlOptions & VaultViewConnectionUpdate;
+export type VaultOpenServiceUrlViewConnectionDelete = VaultOpenServiceUrlOptions & VaultViewConnectionDelete;
+export type VaultOpenServiceUrlViewCustomerSupport = VaultOpenServiceUrlOptions & VaultViewCustomerSupport;
 
 export type LinkKitOpenServiceOptions = ConfigsOptions;
 export type LinkKitOpenServiceUrlOptions = ConfigsOptionsWithoutIsNewTab;
 
 export type OpenServiceOptions =
   | MyAccountOpenServiceOptions
-  | ConfigsOptions
+  | VaultOpenServiceOptions
   | VaultOpenServiceViewServiceList
   | VaultOpenServiceViewConnectionSetting
   | VaultOpenServiceViewConnectionUpdate
@@ -202,7 +221,7 @@ export type OpenServiceOptions =
   | LinkKitOpenServiceOptions;
 export type OpenServiceUrlOptions =
   | MyAccountOpenServiceUrlOptions
-  | ConfigsOptionsWithoutIsNewTab
+  | VaultOpenServiceUrlOptions
   | VaultOpenServiceUrlViewServiceList
   | VaultOpenServiceUrlViewConnectionSetting
   | VaultOpenServiceUrlViewConnectionUpdate


### PR DESCRIPTION
## Summary
- Add `showBackBarOn` option to `openService` and `openServiceUrl` on Vault, which controls the visibility of the back bar button on specific pages
- The option accepts a typed object (`{ view: 'services-list' }`, `{ view: 'connection-setting', credentialId }`, and maps it to Vault's internal `state=url=<path>` query parameter
- The settings only has an effect on mobile viewport; on desktop it is always shown regardless of this setting

###Usage
```javascript
mtLinkSdk.openService('vault', {
  showBackBarOn: { view: 'services-list' }
});

mtLinkSdk.openService('vault', {
  showBackBarOn: { view: 'connection-setting', credentialId: '123' }
});
```

### Sample App demo

https://github.com/user-attachments/assets/bc880056-0c3e-4e9d-9097-6b6c062e8d12


