### PR TITLE
[LON-359] Drop `qs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "create-hash": "^1.2.0",
     "node-fetch": "^2.6.1",
     "process": "^0.11.10",
-    "qs": "^6.10.1",
     "snake-case": "^3.0.4",
     "stream-browserify": "^3.0.0",
     "url-safe-base64": "^1.1.1"
@@ -46,7 +45,6 @@
     "@types/create-hash": "^1.2.6",
     "@types/jest": "^27",
     "@types/node-fetch": "^2.5.10",
-    "@types/qs": "^6.9.6",
     "@types/url-safe-base64": "^1.1.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",

--- a/src/__tests__/helper.test.ts
+++ b/src/__tests__/helper.test.ts
@@ -1,5 +1,4 @@
-import qs from 'qs';
-import { constructScopes, getIsTabValue, mergeConfigs, generateConfigs } from '../helper';
+import { constructScopes, getIsTabValue, mergeConfigs, generateConfigs, queryStringToObject } from '../helper';
 import packageJson from '../../package.json';
 import { AuthnMethod, ConfigsOptions, StoredOptions } from '../typings';
 
@@ -145,7 +144,7 @@ describe('helper', () => {
         mode: 'production'
       };
 
-      expect(qs.parse(await generateConfigs(configPayload))).toEqual({
+      expect(queryStringToObject(await generateConfigs(configPayload))).toEqual({
         email_token: emailToken,
         back_to: 'backTo',
         auth_action: 'signup',
@@ -207,7 +206,7 @@ describe('helper', () => {
         mode: 'production'
       };
 
-      expect(qs.parse(await generateConfigs(configPayload))).toEqual({
+      expect(queryStringToObject(await generateConfigs(configPayload))).toEqual({
         email_token: emailToken,
         back_to: 'backTo',
         auth_action: 'signup',

--- a/src/__tests__/helper.test.ts
+++ b/src/__tests__/helper.test.ts
@@ -3,11 +3,11 @@ import { constructScopes, getIsTabValue, mergeConfigs, generateConfigs } from '.
 import packageJson from '../../package.json';
 import { AuthnMethod, ConfigsOptions, StoredOptions } from '../typings';
 
-const mockFetch = jest.spyOn(global, 'fetch')
+const mockFetch = jest.spyOn(global, 'fetch');
 
 describe('helper', () => {
   beforeEach(() => {
-	  jest.clearAllMocks();
+    jest.clearAllMocks();
   });
 
   test('constuctScopes', () => {
@@ -129,11 +129,11 @@ describe('helper', () => {
 
   describe('generateConfigs', () => {
     test('with parameter', async () => {
-			const emailToken = 'email-token';
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: () => Promise.resolve({ email_token: emailToken })
-			} as Response);
+      const emailToken = 'email-token';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ email_token: emailToken })
+      } as Response);
 
       const configPayload: StoredOptions & ConfigsOptions = {
         email: 'email',
@@ -157,12 +157,14 @@ describe('helper', () => {
       });
     });
 
+    // Percent-encoding spec can be found here:
+    // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#percent_encoding
     test('query encoding should make sure config params are also encoded', async () => {
-			const emailToken = 'token&!@#(*)-304should be_encoded';
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: () => Promise.resolve({ email_token: emailToken })
-			} as Response);
+      const emailToken = 'token&!@#(*)-304should be_encoded';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ email_token: emailToken })
+      } as Response);
 
       const configPayload: StoredOptions & ConfigsOptions = {
         email: 'does not matter',
@@ -175,8 +177,8 @@ describe('helper', () => {
       };
 
       const result = await generateConfigs(configPayload);
-      expect(result).toContain('email_token=token%26%21%40%23%28%2A%29-304should%20be_encoded');
-      expect(result).toContain('back_to=backTo%20%23%21%40with%20%5B%5Dspecial%3D%20chars');
+      expect(result).toContain('email_token=token%26%21%40%23%28*%29-304should+be_encoded');
+      expect(result).toContain('back_to=backTo+%23%21%40with+%5B%5Dspecial%3D+chars');
     });
 
     test('Should raise an error when passing an array in authnMethod', async () => {
@@ -189,11 +191,11 @@ describe('helper', () => {
     });
 
     test('Should reject invalid authnMethod from config', async () => {
-			const emailToken = 'token1234';
-			mockFetch.mockResolvedValueOnce({
-				ok: true,
-				json: () => Promise.resolve({ email_token: emailToken })
-			} as Response);
+      const emailToken = 'token1234';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ email_token: emailToken })
+      } as Response);
 
       const configPayload: StoredOptions & ConfigsOptions = {
         email: 'email',
@@ -216,8 +218,8 @@ describe('helper', () => {
       });
     });
 
-		test('it returns configs without email or emailToken if POST fails', async () => {
-			mockFetch.mockResolvedValueOnce({ ok: false } as Response);
+    test('it returns configs without email or emailToken if POST fails', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false } as Response);
 
       const configPayload: StoredOptions & ConfigsOptions = {
         email: 'email',
@@ -229,10 +231,10 @@ describe('helper', () => {
         mode: 'production'
       };
 
-			const result = await generateConfigs(configPayload);
-			expect(result).not.toContain('email_token');
-			expect(result).not.toContain('email');
-		});
+      const result = await generateConfigs(configPayload);
+      expect(result).not.toContain('email_token');
+      expect(result).not.toContain('email');
+    });
 
     test('without parameter', async () => {
       expect(await generateConfigs()).toBe(`sdk_platform=js&sdk_version=${packageJson.version}`);

--- a/src/__tests__/helper/expect-url-to-match.ts
+++ b/src/__tests__/helper/expect-url-to-match.ts
@@ -1,4 +1,4 @@
-import qs from 'qs';
+import { queryStringToObject } from '../../helper';
 
 export interface UrlExpectation {
   baseUrl: string;
@@ -8,7 +8,7 @@ export interface UrlExpectation {
 
 export default function expectUrlToMatchWithPKCE(actual: URL | string, expectation: UrlExpectation) {
   const url = typeof actual === 'string' ? new URL(actual) : actual;
-  const actualQuery = qs.parse(new URLSearchParams(url.search).toString());
+  const actualQuery = queryStringToObject(url.search);
 
   expect(actualQuery.code_challenge).toBeDefined();
   delete actualQuery.code_challenge; // ignore PKCE code challenge because it's randomly generated

--- a/src/__tests__/objectToQueryString.ts
+++ b/src/__tests__/objectToQueryString.ts
@@ -1,0 +1,27 @@
+import { objectToQueryString } from '../helper';
+
+describe('objectToQueryString', () => {
+  it('transforms object to query string', () => {
+    const paramsObject = { key1: 'value1', key2: 'value2' };
+
+    expect(objectToQueryString(paramsObject)).toEqual('key1=value1&key2=value2');
+  });
+
+  it('casts boolean values to strings', () => {
+    const paramsObject = { true_key: true, false_key: false };
+
+    expect(objectToQueryString(paramsObject)).toEqual('true_key=true&false_key=false');
+  });
+
+  it('ignores keys where values are undefined', () => {
+    const paramsObject = { undefined_key: undefined, defined_key: 'defined' };
+
+    expect(objectToQueryString(paramsObject)).toEqual('defined_key=defined');
+  });
+
+  it('ignores keys where values are null', () => {
+    const paramsObject = { null_key: null, not_null_key: 'not_null' };
+
+    expect(objectToQueryString(paramsObject)).toEqual('not_null_key=not_null');
+  });
+});

--- a/src/__tests__/queryStringToObject.ts
+++ b/src/__tests__/queryStringToObject.ts
@@ -1,0 +1,21 @@
+import { queryStringToObject } from '../helper';
+
+describe('queryStringToObject', () => {
+  it('transforms object to query string', () => {
+    const queryString = 'key1=value1&key2=value2';
+
+    expect(queryStringToObject(queryString)).toEqual({ key1: 'value1', key2: 'value2' });
+  });
+
+  it('casts boolean values to strings', () => {
+    const queryString = 'true_key=true&false_key=false';
+
+    expect(queryStringToObject(queryString)).toEqual({ true_key: 'true', false_key: 'false' });
+  });
+
+  it('ignores keys without values', () => {
+    const queryString = 'defined_key=defined&undefined_key=';
+
+    expect(queryStringToObject(queryString)).toEqual({ defined_key: 'defined' });
+  });
+});

--- a/src/api/__tests__/logout-url.test.ts
+++ b/src/api/__tests__/logout-url.test.ts
@@ -1,16 +1,14 @@
-import qs from 'qs';
-
 import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
 import logoutUrl from '../logout-url';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 
 describe('api', () => {
   describe('logout-url', () => {
     test('without calling init', async () => {
       const url = await logoutUrl(new MtLinkSdk().storedOptions);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -31,7 +29,7 @@ describe('api', () => {
       });
       const url = await logoutUrl(mtLinkSkd.storedOptions);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -50,7 +48,7 @@ describe('api', () => {
         backTo
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ backTo, mode: 'production' })
       });
 

--- a/src/api/__tests__/logout.test.ts
+++ b/src/api/__tests__/logout.test.ts
@@ -1,9 +1,7 @@
-import qs from 'qs';
-
 import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
 import logout from '../logout';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 
 describe('api', () => {
   describe('logout', () => {
@@ -14,7 +12,7 @@ describe('api', () => {
 
       expect(window.open).toBeCalledTimes(1);
 
-      const query = qs.stringify({ configs: await generateConfigs() });
+      const query = objectToQueryString({ configs: await generateConfigs() });
       const url = `${MY_ACCOUNT_DOMAINS.production}/guests/logout?${query}`;
       expect(window.open).toBeCalledWith(url, '_self', 'noreferrer');
     });
@@ -35,7 +33,7 @@ describe('api', () => {
 
       expect(window.open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -54,7 +52,7 @@ describe('api', () => {
 
       expect(window.open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ backTo, mode: 'production' })
       });
       const url = `${MY_ACCOUNT_DOMAINS.production}/guests/logout?${query}`;

--- a/src/api/__tests__/open-service-url.test.ts
+++ b/src/api/__tests__/open-service-url.test.ts
@@ -1,9 +1,7 @@
-import qs from 'qs';
-
 import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
 import openServiceUrl from '../open-service-url';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 
 describe('api', () => {
   describe('open-service-url', () => {
@@ -12,7 +10,7 @@ describe('api', () => {
     test('myaccount', async () => {
       const url = await openServiceUrl(new MtLinkSdk().storedOptions, 'myaccount');
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -24,7 +22,7 @@ describe('api', () => {
         view: 'settings/change-language'
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -36,7 +34,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -52,7 +50,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' }),
         group: 'grouping_testing',
         type: 'bank',
@@ -69,7 +67,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -83,7 +81,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -97,7 +95,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -111,7 +109,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -124,7 +122,7 @@ describe('api', () => {
         showRememberMe: false
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
 
@@ -140,7 +138,7 @@ describe('api', () => {
       const url = await openServiceUrl(sdk.storedOptions, 'vault', { view: 'onboarding' });
       const configs = await generateConfigs();
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -153,7 +151,7 @@ describe('api', () => {
     test('link-kit', async () => {
       const url = await openServiceUrl(new MtLinkSdk().storedOptions, 'link-kit');
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -172,7 +170,7 @@ describe('api', () => {
 
       const url = await openServiceUrl(mtLinkSdk.storedOptions, 'myaccount');
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -187,7 +185,7 @@ describe('api', () => {
         showBackBarOn: { view: 'services-list' }
       });
 
-      const query = qs.stringify({ state: 'url=/services', configs: await generateConfigs() });
+      const query = objectToQueryString({ state: 'url=/services', configs: await generateConfigs() });
 
       expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
     });
@@ -197,7 +195,7 @@ describe('api', () => {
         showBackBarOn: { view: 'connection-setting', credentialId: '123' }
       });
 
-      const query = qs.stringify({ state: 'url=/connection/123', configs: await generateConfigs() });
+      const query = objectToQueryString({ state: 'url=/connection/123', configs: await generateConfigs() });
 
       expect(url).toBe(`${VAULT_DOMAINS.production}?${query}`);
     });
@@ -214,7 +212,7 @@ describe('api', () => {
 
       const url = await openServiceUrl(instance.storedOptions, 'myaccount');
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: 'clientId',
         saml_subject_id: 'samlSubjectId',
         configs: await generateConfigs()
@@ -229,7 +227,7 @@ describe('api', () => {
 
       const url = await openServiceUrl(instance.storedOptions, 'myaccount');
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: 'clientId',
         configs: await generateConfigs()
       });

--- a/src/api/__tests__/open-service.test.ts
+++ b/src/api/__tests__/open-service.test.ts
@@ -1,9 +1,7 @@
-import qs from 'qs';
-
 import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
 import openService from '../open-service';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 
 describe('api', () => {
   describe('open-service', () => {
@@ -21,7 +19,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
       const url = `${MY_ACCOUNT_DOMAINS.production}/?${query}`;
@@ -36,7 +34,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
       const url = `${MY_ACCOUNT_DOMAINS.production}/settings/change-language?${query}`;
@@ -53,7 +51,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}?${query}`;
@@ -78,7 +76,7 @@ describe('api', () => {
         showRememberMe: false,
         mode: 'production'
       });
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs,
         group: 'grouping_testing',
         type: 'bank',
@@ -100,7 +98,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}/service/fauxbank_test_bank?${query}`;
@@ -119,7 +117,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}/connection/123?${query}`;
@@ -138,7 +136,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}/connection/123/update?${query}`;
@@ -157,7 +155,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}/connection/123/delete?${query}`;
@@ -175,7 +173,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs({ showRememberMe: false, mode: 'production' })
       });
       const url = `${VAULT_DOMAINS.production}/customer-support?${query}`;
@@ -192,7 +190,7 @@ describe('api', () => {
       await openService(sdk.storedOptions, 'vault', { view: 'onboarding' });
       const configs = await generateConfigs();
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -213,7 +211,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
       const url = `${LINK_KIT_DOMAINS.production}?${query}`;
@@ -237,7 +235,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,
@@ -264,7 +262,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: 'clientId',
         saml_subject_id: 'samlSubjectId',
         configs: await generateConfigs()
@@ -284,7 +282,7 @@ describe('api', () => {
 
       expect(open).toBeCalledTimes(1);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: 'clientId',
         configs: await generateConfigs()
       });

--- a/src/api/__tests__/request-login-link.test.ts
+++ b/src/api/__tests__/request-login-link.test.ts
@@ -1,12 +1,11 @@
 declare const __VERSION__: string;
 
 import fetch from 'jest-fetch-mock';
-import qs from 'qs';
 
 import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
 import requestLoginLink from '../request-login-link';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 
 describe('api', () => {
   describe('request-login-link', () => {
@@ -35,7 +34,7 @@ describe('api', () => {
 
       await requestLoginLink(new MtLinkSdk().storedOptions, { email });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -64,7 +63,7 @@ describe('api', () => {
         loginLinkTo: 'settings/delete-account'
       });
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         configs: await generateConfigs()
       });
 
@@ -109,7 +108,7 @@ describe('api', () => {
 
       await requestLoginLink(mtLinkSdk.storedOptions);
 
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         cobrand_client_id: cobrandClientId,
         locale,

--- a/src/api/__tests__/token-info.test.ts
+++ b/src/api/__tests__/token-info.test.ts
@@ -1,11 +1,10 @@
 declare const __VERSION__: string;
 
 import fetch from 'jest-fetch-mock';
-import qs from 'qs';
 
 import { MY_ACCOUNT_DOMAINS } from '../../server-paths';
 import { MtLinkSdk } from '../..';
-import { generateConfigs } from '../../helper';
+import { generateConfigs, objectToQueryString } from '../../helper';
 import tokenInfo from '../token-info';
 
 describe('api', () => {
@@ -43,7 +42,7 @@ describe('api', () => {
       fetch.mockResponseOnce(JSON.stringify(response));
 
       await tokenInfo(mtLinkSdk.storedOptions, token);
-      const query = qs.stringify({
+      const query = objectToQueryString({
         client_id: clientId,
         configs: await generateConfigs()
       });

--- a/src/api/authorize-url.ts
+++ b/src/api/authorize-url.ts
@@ -1,6 +1,4 @@
-import { stringify } from 'qs';
-
-import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge } from '../helper';
+import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, AuthorizeUrlOptions } from '../typings';
 import storage from '../storage';
@@ -43,7 +41,7 @@ export default async function authorize(
   const cc = codeChallenge || generateCodeChallenge();
 
   const configs = await generateConfigs(mergeConfigs(storedOptions, rest));
-  const queryString = stringify({
+  const queryString = objectToQueryString({
     client_id: clientId,
     cobrand_client_id: cobrandClientId,
     response_type: 'code',

--- a/src/api/exchange-token.ts
+++ b/src/api/exchange-token.ts
@@ -1,19 +1,13 @@
-import qs from 'qs';
-
-import { generateSdkHeaderInfo } from '../helper';
+import { generateSdkHeaderInfo, queryStringToObject } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, ExchangeTokenOptions, Token } from '../typings';
 import storage from '../storage';
 
 function getCode(): string | undefined {
   // not available in node environment
-  if (!window) {
-    return;
-  }
+  if (!window) return;
 
-  const { code } = qs.parse(window.location.search, {
-    ignoreQueryPrefix: true
-  });
+  const { code } = queryStringToObject(window.location.search);
 
   return (Array.isArray(code) ? code[code.length - 1] : code) as string | undefined;
 }

--- a/src/api/logout-url.ts
+++ b/src/api/logout-url.ts
@@ -1,6 +1,4 @@
-import { stringify } from 'qs';
-
-import { generateConfigs, mergeConfigs } from '../helper';
+import { generateConfigs, mergeConfigs, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, LogoutUrlOptions } from '../typings';
 
@@ -8,7 +6,7 @@ export default async function logoutUrl(storedOptions: StoredOptions, options: L
   const { clientId, mode, cobrandClientId, locale, samlSubjectId } = storedOptions;
 
   const configs = await generateConfigs(mergeConfigs(storedOptions, options));
-  const queryString = stringify({
+  const queryString = objectToQueryString({
     client_id: clientId,
     cobrand_client_id: cobrandClientId,
     locale,

--- a/src/api/onboard-url.ts
+++ b/src/api/onboard-url.ts
@@ -1,6 +1,4 @@
-import { stringify } from 'qs';
-
-import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge } from '../helper';
+import { constructScopes, generateConfigs, mergeConfigs, generateCodeChallenge, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, OnboardUrlOptions } from '../typings';
 import storage from '../storage';
@@ -36,7 +34,7 @@ export default async function onboardUrl(
 
   const cc = codeChallenge || generateCodeChallenge();
 
-  const queryString = stringify({
+  const queryString = objectToQueryString({
     client_id: clientId,
     cobrand_client_id: cobrandClientId,
     response_type: 'code',

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -21,7 +21,7 @@ import {
   VaultOpenServiceUrlViewOnboarding
 } from '../typings';
 
-interface QueryData {
+export interface QueryData {
   client_id?: string;
   cobrand_client_id?: string;
   locale?: string;

--- a/src/api/open-service-url.ts
+++ b/src/api/open-service-url.ts
@@ -1,6 +1,4 @@
-import { stringify } from 'qs';
-
-import { generateConfigs, mergeConfigs } from '../helper';
+import { generateConfigs, mergeConfigs, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS, VAULT_DOMAINS, LINK_KIT_DOMAINS } from '../server-paths';
 import {
   StoredOptions,
@@ -115,7 +113,7 @@ export default async function openServiceUrl(
       return query;
     }
 
-    return stringify(query);
+    return objectToQueryString(query);
   };
 
   const { view: vaultView } = options as VaultServiceTypes;
@@ -131,7 +129,7 @@ export default async function openServiceUrl(
           // eslint-disable-next-line no-case-declarations
           const { group, type, search } = options as VaultViewServiceList;
 
-          return `${VAULT_DOMAINS[mode]}/services?${stringify({
+          return `${VAULT_DOMAINS[mode]}/services?${objectToQueryString({
             ...(getQueryValue(false) as QueryData),
             group,
             type,

--- a/src/api/request-login-link.ts
+++ b/src/api/request-login-link.ts
@@ -1,6 +1,4 @@
-import { stringify } from 'qs';
-
-import { generateConfigs, mergeConfigs, generateSdkHeaderInfo } from '../helper';
+import { generateConfigs, mergeConfigs, generateSdkHeaderInfo, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, RequestLoginLinkOptions } from '../typings';
 
@@ -18,7 +16,7 @@ export default async function requestLoginLink(
     );
   }
 
-  const queryString = stringify({
+  const queryString = objectToQueryString({
     client_id: clientId,
     cobrand_client_id: cobrandClientId,
     locale,

--- a/src/api/token-info.ts
+++ b/src/api/token-info.ts
@@ -1,5 +1,4 @@
-import { stringify } from 'qs';
-import { generateConfigs, generateSdkHeaderInfo } from '../helper';
+import { generateConfigs, generateSdkHeaderInfo, objectToQueryString } from '../helper';
 import { MY_ACCOUNT_DOMAINS } from '../server-paths';
 import { StoredOptions, TokenInfo } from '../typings';
 
@@ -10,7 +9,7 @@ export default async function tokenInfo(storedOptions: StoredOptions, token: str
     throw new Error('[mt-link-sdk] Missing parameter `token` in `tokenInfo`.');
   }
 
-  const queryString = stringify({
+  const queryString = objectToQueryString({
     client_id: clientId,
     cobrand_client_id: storedOptions.cobrandClientId,
     configs: await generateConfigs(storedOptions)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -176,3 +176,15 @@ function isAuthAction(x: unknown): x is AuthAction {
 function parseAuthAction(x: unknown): AuthAction | undefined {
   return isAuthAction(x) ? x : undefined;
 }
+
+export function objectToQueryString(paramsObject: object): string {
+  const urlSearchParams = new URLSearchParams();
+
+  Object.entries(paramsObject).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+
+    urlSearchParams.append(key, value.toString());
+  });
+
+  return urlSearchParams.toString();
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,5 @@
 declare const __VERSION__: string;
 
-import { stringify } from 'qs';
 import { snakeCase } from 'snake-case';
 import createHash from 'create-hash';
 import { encode } from 'url-safe-base64';
@@ -131,7 +130,7 @@ export async function generateConfigs(
     }
   }
 
-  return stringify(snakeCaseConfigs);
+  return objectToQueryString(snakeCaseConfigs);
 }
 
 export function generateCodeChallenge(): string {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -187,3 +187,16 @@ export function objectToQueryString(paramsObject: object): string {
 
   return urlSearchParams.toString();
 }
+
+export function queryStringToObject(queryString: string): Record<string, string> {
+  const urlSearchParams = new URLSearchParams(queryString);
+  const paramsObject: Record<string, string> = {};
+
+  urlSearchParams.forEach((value, key) => {
+    if (!value) return;
+
+    paramsObject[key] = value.toString();
+  });
+
+  return paramsObject;
+}

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -18,6 +18,7 @@ import {
   StoredOptions
 } from './typings';
 import { MY_ACCOUNT_DOMAINS } from './server-paths';
+import type { QueryData } from './api/open-service-url';
 
 export function constructScopes(scopes: Scopes = ''): string | undefined {
   return (Array.isArray(scopes) ? scopes.join(' ') : scopes) || undefined;
@@ -176,7 +177,7 @@ function parseAuthAction(x: unknown): AuthAction | undefined {
   return isAuthAction(x) ? x : undefined;
 }
 
-export function objectToQueryString(paramsObject: object): string {
+export function objectToQueryString(paramsObject: Record<string, unknown> | QueryData): string {
   const urlSearchParams = new URLSearchParams();
 
   Object.entries(paramsObject).forEach(([key, value]) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,7 +1414,6 @@ __metadata:
     "@types/create-hash": "npm:^1.2.6"
     "@types/jest": "npm:^27"
     "@types/node-fetch": "npm:^2.5.10"
-    "@types/qs": "npm:^6.9.6"
     "@types/url-safe-base64": "npm:^1.1.0"
     "@types/uuid": "npm:^8.3.0"
     "@typescript-eslint/eslint-plugin": "npm:^4.23.0"
@@ -1433,7 +1432,6 @@ __metadata:
     node-fetch: "npm:^2.6.1"
     prettier: "npm:^2.3.0"
     process: "npm:^0.11.10"
-    qs: "npm:^6.10.1"
     snake-case: "npm:^3.0.4"
     stream-browserify: "npm:^3.0.0"
     ts-jest: "npm:^27"
@@ -1792,13 +1790,6 @@ __metadata:
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
   checksum: 10c0/0960b5c1115bb25e979009d0b44c42cf3d792accf24085e4bfce15aef5794ea042e04e70c2139a2c3387f781f18c89b5706f000ddb089e9a4a2ccb7536a2c5f0
-  languageName: node
-  linkType: hard
-
-"@types/qs@npm:^6.9.6":
-  version: 6.15.1
-  resolution: "@types/qs@npm:6.15.1"
-  checksum: 10c0/1dfdbcb4cf2a8f66d57f0b9a9fe6b1c7091cb816687b6698c1351eaf31f62e412cea9b7453a9637b570cd5fad8dced527e5a9e69b4fcc6e318daacd8b749f094
   languageName: node
   linkType: hard
 
@@ -2749,7 +2740,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2, braces@npm:^3.0.3, braces@npm:~3.0.2":
+"braces@npm:^3.0.2, braces@npm:~3.0.2":
+  version: 3.0.2
+  resolution: "braces@npm:3.0.2"
+  dependencies:
+    fill-range: "npm:^7.0.1"
+  checksum: 10c0/321b4d675791479293264019156ca322163f02dc06e3c4cab33bb15cd43d80b51efef69b0930cfde3acd63d126ebca24cd0544fa6f261e093a0fb41ab9dda381
+  languageName: node
+  linkType: hard
+
+"braces@npm:^3.0.3":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -2852,7 +2852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bound@npm:^1.0.2, call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
+"call-bound@npm:^1.0.3, call-bound@npm:^1.0.4":
   version: 1.0.4
   resolution: "call-bound@npm:1.0.4"
   dependencies:
@@ -4721,6 +4721,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fill-range@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "fill-range@npm:7.0.1"
+  dependencies:
+    to-regex-range: "npm:^5.0.1"
+  checksum: 10c0/7cdad7d426ffbaadf45aeb5d15ec675bbd77f7597ad5399e3d2766987ed20bda24d5fac64b3ee79d93276f5865608bb22344a26b9b1ae6c4d00bd94bf611623f
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -4815,10 +4824,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.1.0, flatted@npm:^3.2.9":
+"flatted@npm:^3.1.0":
   version: 3.4.3
   resolution: "flatted@npm:3.4.3"
   checksum: 10c0/0b36eba483a68dda5a2c4dda9cab61dc1c57a3bd9bd6942d1c6fac9c94c86fb6295c7167f33f94f72b5a79ccf95bf5c2a0cf99f73888ef858252439e149bf24b
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.2.9":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -4962,7 +4978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -7432,13 +7448,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
-  version: 1.13.4
-  resolution: "object-inspect@npm:1.13.4"
-  checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
-  languageName: node
-  linkType: hard
-
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -7832,17 +7841,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.0, picomatch@npm:^4.0.4":
+"picomatch@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "picomatch@npm:2.3.1"
+  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.0":
   version: 4.0.5
   resolution: "picomatch@npm:4.0.5"
   checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -8050,16 +8073,6 @@ __metadata:
   version: 1.5.1
   resolution: "q@npm:1.5.1"
   checksum: 10c0/7855fbdba126cb7e92ef3a16b47ba998c0786ec7fface236e3eb0135b65df36429d91a86b1fff3ab0927b4ac4ee88a2c44527c7c3b8e2a37efbec9fe34803df4
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.10.1":
-  version: 6.15.3
-  resolution: "qs@npm:6.15.3"
-  dependencies:
-    es-define-property: "npm:^1.0.1"
-    side-channel: "npm:^1.1.1"
-  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
   languageName: node
   linkType: hard
 
@@ -8704,54 +8717,6 @@ __metadata:
   bin:
     shjs: bin/shjs
   checksum: 10c0/feb25289a12e4bcd04c40ddfab51aff98a3729f5c2602d5b1a1b95f6819ec7804ac8147ebd8d9a85dfab69d501bcf92d7acef03247320f51c1552cec8d8e2382
-  languageName: node
-  linkType: hard
-
-"side-channel-list@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "side-channel-list@npm:1.0.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
-  languageName: node
-  linkType: hard
-
-"side-channel-map@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "side-channel-map@npm:1.0.1"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.5"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10c0/010584e6444dd8a20b85bc926d934424bd809e1a3af941cace229f7fdcb751aada0fb7164f60c2e22292b7fa3c0ff0bce237081fd4cdbc80de1dc68e95430672
-  languageName: node
-  linkType: hard
-
-"side-channel-weakmap@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "side-channel-weakmap@npm:1.0.2"
-  dependencies:
-    call-bound: "npm:^1.0.2"
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.5"
-    object-inspect: "npm:^1.13.3"
-    side-channel-map: "npm:^1.0.1"
-  checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "side-channel@npm:1.1.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-    side-channel-list: "npm:^1.0.1"
-    side-channel-map: "npm:^1.0.1"
-    side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Similar to the [Vault PRs](https://github.com/moneytree/mt-vault/pulls?q=is%3Apr+LON-359) we don't need `qs` anymore; there's a [widely supported](https://caniuse.com/?search=URLSearchParams) native way to do it. 

This adds some helpers using `URLSearchParams` to get the types right/get around `Object.fromEntries` not being available in the JS versions we target, and replaces all usage of `qs` with them.

I did have to change one test to get it to pass, because `qs` encoded characters which shouldn't be encoded according to the [spec](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set) and didn't encode spaces as `+`. I don't think this is likely to be a breaking change since it's just conforming to the spec, but let me know if you think otherwise.