### PR TITLE
build(deps): move cspell and typedoc to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,11 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "create-hash": "^1.2.0",
-    "cspell": "^7.3.7",
     "node-fetch": "^2.6.1",
     "process": "^0.11.10",
     "qs": "^6.10.1",
     "snake-case": "^3.0.4",
     "stream-browserify": "^3.0.0",
-    "typedoc": "^0.25.1",
     "url-safe-base64": "^1.1.1"
   },
   "devDependencies": {
@@ -54,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "conventional-changelog-cli": "^2.1.1",
+    "cspell": "^7.3.7",
     "docsify-cli": "^4.4.3",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
@@ -64,6 +63,7 @@
     "prettier": "^2.3.0",
     "ts-jest": "^27",
     "ts-loader": "^9",
+    "typedoc": "^0.25.1",
     "typescript": "^4.2.4",
     "webpack": "^5",
     "webpack-cli": "^5"


### PR DESCRIPTION
`cspell` and `typedoc` are listed under `dependencies`, but they are only used by the `spellcheck` and `build:docs` scripts. Nothing under `src/` imports either of them, and the published package only ships `dist/`.

Because they are runtime dependencies, every application that installs `@moneytree/mt-link-javascript-sdk` installs them too. Measured with npm against the published 5.1.0:

| | packages | node_modules | `npm audit` |
|---|---|---|---|
| current | 228 | 72 MB | 9 high |
| without cspell/typedoc | 62 | 4.3 MB | 0 |

All nine advisories come from the cspell/typedoc trees (brace-expansion, minimatch, glob, rimraf, flat-cache, file-entry-cache), so they show up in consumers' audits even though neither tool ever runs in their app.

Verified locally with this change applied:

- `yarn install` — `yarn.lock` is unchanged (Yarn 4 records workspace dependencies in a single list, so moving between sections does not affect it)
- `yarn test` — 15 suites / 110 tests pass
- `yarn lint` — same 4 pre-existing warnings, no new ones
- `yarn build` — succeeds; the regenerated `dist/` is byte-identical
- `yarn build:docs` and `yarn spellcheck` — still work, since both tools remain installed for development

This will conflict trivially with #225 (typedoc bump) depending on which lands first — happy to rebase.