### PR TITLE
chore(deps): correctly classify dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,11 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "create-hash": "^1.2.0",
-    "cspell": "^7.3.7",
     "node-fetch": "^2.6.1",
     "process": "^0.11.10",
     "qs": "^6.10.1",
     "snake-case": "^3.0.4",
     "stream-browserify": "^3.0.0",
-    "typedoc": "^0.25.1",
     "url-safe-base64": "^1.1.1"
   },
   "devDependencies": {
@@ -54,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "conventional-changelog-cli": "^2.1.1",
+    "cspell": "^7.3.7",
     "docsify-cli": "^4.4.3",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
@@ -64,6 +63,7 @@
     "prettier": "^2.3.0",
     "ts-jest": "^27",
     "ts-loader": "^9",
+    "typedoc": "^0.25.1",
     "typescript": "^4.2.4",
     "webpack": "^5",
     "webpack-cli": "^5"


### PR DESCRIPTION
`cspell` and `typedoc` aren't needed as runtime dependencies, this moves them to `devDependencies`