### PR TITLE
[LON-427] Drop snake-case package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "buffer": "^6.0.3",
     "create-hash": "^1.2.0",
     "process": "^0.11.10",
-    "snake-case": "^3.0.4",
     "stream-browserify": "^3.0.0",
     "url-safe-base64": "^1.1.1"
   },

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -72,7 +72,6 @@ __metadata:
     buffer: "npm:^6.0.3"
     create-hash: "npm:^1.2.0"
     process: "npm:^0.11.10"
-    snake-case: "npm:^3.0.4"
     stream-browserify: "npm:^3.0.0"
     url-safe-base64: "npm:^1.1.1"
   languageName: node
@@ -4536,16 +4535,6 @@ __metadata:
   version: 3.0.3
   resolution: "signal-exit@npm:3.0.3"
   checksum: 10c0/645cf460a417158e7d7fd03fb276aa12aecc49ab61a2ea36dac1987870a454e8af476ed926c8a8713a1adfde69c5964a4ca322c87fcca2367b36e1681207cf5f
-  languageName: node
-  linkType: hard
-
-"snake-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "snake-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
   languageName: node
   linkType: hard
 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,5 @@
 declare const __VERSION__: string;
 
-import { snakeCase } from 'snake-case';
 import createHash from 'create-hash';
 import { encode } from 'url-safe-base64';
 import { v4 as uuid } from 'uuid';
@@ -19,6 +18,7 @@ import {
 } from './typings';
 import { MY_ACCOUNT_DOMAINS } from './server-paths';
 import type { QueryData } from './api/open-service-url';
+import { snakeCase } from './snakeCase';
 
 export function constructScopes(scopes: Scopes = ''): string | undefined {
   return (Array.isArray(scopes) ? scopes.join(' ') : scopes) || undefined;

--- a/src/snakeCase.ts
+++ b/src/snakeCase.ts
@@ -1,0 +1,13 @@
+type SnakeCase<S extends string> = S extends `${infer Head}${infer Tail}`
+  ? Head extends Uppercase<Head>
+    ? `_${Lowercase<Head>}${SnakeCase<Tail>}`
+    : `${Head}${SnakeCase<Tail>}`
+  : S;
+
+/**
+ * Converts a camelCase string to snake_case  string.
+ * e.g., "testString" -> "test_string"
+ */
+export function snakeCase<S extends string>(str: S): SnakeCase<S> {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`) as SnakeCase<S>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,6 @@ __metadata:
     jest-fetch-mock: "npm:^3.0.3"
     prettier: "npm:^2.3.0"
     process: "npm:^0.11.10"
-    snake-case: "npm:^3.0.4"
     stream-browserify: "npm:^3.0.0"
     ts-jest: "npm:^27"
     ts-loader: "npm:^9"
@@ -4072,16 +4071,6 @@ __metadata:
   version: 2.5.9
   resolution: "dompurify@npm:2.5.9"
   checksum: 10c0/91cf3fd8ad07f969a740813a2101d573547954fd87925d729e8cfc592fa93c51fc3f7b298d336bd90c1a5eae1ad65d1ca06254b938fd84af84ef081c9c4b75ee
-  languageName: node
-  linkType: hard
-
-"dot-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "dot-case@npm:3.0.4"
-  dependencies:
-    no-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/5b859ea65097a7ea870e2c91b5768b72ddf7fa947223fd29e167bcdff58fe731d941c48e47a38ec8aa8e43044c8fbd15cd8fa21689a526bc34b6548197cd5b05
   languageName: node
   linkType: hard
 
@@ -6864,15 +6853,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lower-case@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "lower-case@npm:2.0.2"
-  dependencies:
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/3d925e090315cf7dc1caa358e0477e186ffa23947740e4314a7429b6e62d72742e0bbe7536a5ae56d19d7618ce998aba05caca53c2902bd5742fdca5fc57fd7b
-  languageName: node
-  linkType: hard
-
 "lowercase-keys@npm:^1.0.0, lowercase-keys@npm:^1.0.1":
   version: 1.0.1
   resolution: "lowercase-keys@npm:1.0.1"
@@ -7290,16 +7270,6 @@ __metadata:
   version: 2.1.0
   resolution: "nested-error-stacks@npm:2.1.0"
   checksum: 10c0/8d4e8f81a66be0910d766b3a5972117b0a65bade2f18b2dcb414489e73f93d84dd2b88d5cbf3550b7f427c2f2bbfe2e6e2945b228eefe3328b1fde335df220d1
-  languageName: node
-  linkType: hard
-
-"no-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "no-case@npm:3.0.4"
-  dependencies:
-    lower-case: "npm:^2.0.2"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
   languageName: node
   linkType: hard
 
@@ -8734,16 +8704,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snake-case@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "snake-case@npm:3.0.4"
-  dependencies:
-    dot-case: "npm:^3.0.4"
-    tslib: "npm:^2.0.3"
-  checksum: 10c0/ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
-  languageName: node
-  linkType: hard
-
 "source-map-resolve@npm:^0.6.0":
   version: 0.6.0
   resolution: "source-map-resolve@npm:0.6.0"
@@ -9433,13 +9393,6 @@ __metadata:
   version: 1.13.0
   resolution: "tslib@npm:1.13.0"
   checksum: 10c0/ae615d9a69f605a31beec7619ebd102961220fae79a3a4cb8f9740baf48d2f3d0d16461a39a43a4b7c139713b4535d3bfe32efab749854fb169d053188f23410
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.0.3":
-  version: 2.2.0
-  resolution: "tslib@npm:2.2.0"
-  checksum: 10c0/62c705c4d73bcafa3e191df21ed8f024497b61f0e97c3f3e864ae51bcc98d31b830f73ab94b12f7c0dbd2e8f26af759cb521dd61ae88793f0f2abc32b43599a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We have logic for this (and more complex usecases) in other projects; this PR introduces the simplest possible version here to allow dropping a dependency.

I also update the `/sample` directory `yarn.lock` to reflect recently removed dependencies by running `yarn install`.