### PR TITLE
[LON-427] Move `process` dependency to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "start:docs": "docsify serve docs",
     "prepare": "husky install"
   },
-  "dependencies": {
-    "process": "^0.11.10"
-  },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
@@ -51,6 +48,7 @@
     "jest": "^27",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.3.0",
+    "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "ts-jest": "^27",
     "ts-loader": "^9",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -68,8 +68,6 @@ __metadata:
 "@moneytree/mt-link-javascript-sdk@portal:../::locator=mt-link-javascript-sdk-sample%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@moneytree/mt-link-javascript-sdk@portal:../::locator=mt-link-javascript-sdk-sample%40workspace%3A."
-  dependencies:
-    process: "npm:^0.11.10"
   languageName: node
   linkType: soft
 
@@ -3703,13 +3701,6 @@ __metadata:
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
-  languageName: node
-  linkType: hard
-
-"process@npm:^0.11.10":
-  version: 0.11.10
-  resolution: "process@npm:0.11.10"
-  checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`process` is used to add a polyfill during the build; it's not necessary at runtime.