### PR TITLE
[LON-427] Add ESM output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "5.1.0",
   "description": "Moneytree Link JavaScript SDK",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist/"
   ],

--- a/sample/vite.config.ts
+++ b/sample/vite.config.ts
@@ -7,10 +7,5 @@ export default defineConfig({
   server: {
     // So it can run without conflicting with Vault
     port: 9001
-  },
-
-  // So it can bundle CJS -> ESM through the portal
-  optimizeDeps: {
-    include: ['@moneytree/mt-link-javascript-sdk']
   }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,16 +15,22 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-      formats: ['cjs'],
-      fileName: () => 'index.js'
+      entry: path.resolve(__dirname, 'src/index.ts')
     },
     rollupOptions: {
-      output: {
-        // Match the old webpack commonjs2 output shape: module.exports carries
-        // both the default export (under `.default`) and all named exports.
-        exports: 'named'
-      }
+      output: [
+        {
+          format: 'cjs',
+          entryFileNames: 'index.js',
+          // Match the old webpack commonjs2 output shape: module.exports carries
+          // both the default export (under `.default`) and all named exports.
+          exports: 'named'
+        },
+        {
+          format: 'es',
+          entryFileNames: 'index.mjs'
+        }
+      ]
     }
   }
 });


### PR DESCRIPTION
Adds ESM output alongside our existing CJS build and updates the sample app to consume ESM, as it should be the preferred output going forward. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>