### PR TITLE
[LON-427] Fix indentation typo in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
   test_on_pr:
     jobs:
       - start:
-        <<: *filters_master_out
+          <<: *filters_master_out
       - security-tools/supply_chain_guard:
           context: new_github_mtservice_read
           requires:


### PR DESCRIPTION
The filter wasn't working because YAML indentation is fun