### PR TITLE
fix(build): don't build test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Moneytree",
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && vite build && tsc --emitDeclarationOnly",
+    "build": "rm -rf dist && vite build && tsc --emitDeclarationOnly -p tsconfig.build.json",
     "build:docs": "rm -rf docs/types && typedoc --out docs/types src",
     "prepareRelease": "npm run build && git add dist && npm run build:docs && git add docs",
     "createChangelog": "conventional-changelog -p conventionalcommits && git add CHANGELOG.md",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./dist",
+    "./node_modules",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx",
+    "./src/**/*.spec.ts",
+    "./src/**/*.spec.tsx"
+  ]
+}


### PR DESCRIPTION
Self explanatory, we don't need type definitions for test files